### PR TITLE
fix: run ci lint via docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,9 @@ env:
 install:
   - go mod download
 
-before_script:
-  - wget -O - -q https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.16.0
-
 script:
-  - go test ./... -race -coverprofile=coverage.txt -covermode=atomic
-  - bin/golangci-lint run
+  - docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint golangci-lint run
+  - go test -race -coverprofile=coverage.txt -covermode=atomic
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/api/riot_api.go
+++ b/api/riot_api.go
@@ -417,7 +417,7 @@ func (c RiotAPIClient) UpdateTournament(code string, parameters model.Tournament
 		"method": "UpdateTournament",
 		"Region": c.Region,
 	})
-	if _, err := c.put(fmt.Sprintf(endpointUpdateTournament, code), parameters); err != nil {
+	if err := c.put(fmt.Sprintf(endpointUpdateTournament, code), parameters); err != nil {
 		logger.Error(err)
 		return err
 	}
@@ -494,7 +494,7 @@ func (c RiotAPIClient) postInto(endpoint string, body, target interface{}) error
 	return nil
 }
 
-func (c RiotAPIClient) put(endpoint string, body interface{}) (*http.Response, error) {
+func (c RiotAPIClient) put(endpoint string, body interface{}) error {
 	logger := c.logger.WithFields(log.Fields{
 		"method":   "put",
 		"Region":   c.Region,
@@ -503,9 +503,10 @@ func (c RiotAPIClient) put(endpoint string, body interface{}) (*http.Response, e
 	buf := &bytes.Buffer{}
 	if err := json.NewEncoder(buf).Encode(body); err != nil {
 		logger.Error(err)
-		return nil, err
+		return err
 	}
-	return c.doRequest("PUT", endpoint, buf)
+	_, err := c.doRequest("PUT", endpoint, buf)
+	return err
 }
 
 func (c RiotAPIClient) get(endpoint string) (*http.Response, error) {

--- a/api/riot_api_test.go
+++ b/api/riot_api_test.go
@@ -23,7 +23,7 @@ func TestRiotAPIClient_GetSummonerByName(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name: "get repsonse",
+			name: "get response",
 			want: &model.Summoner{},
 			doer: mock.NewJSONMockDoer(&model.Summoner{}, 200),
 		},
@@ -1619,7 +1619,7 @@ func TestRiotAPIClient_put(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := NewRiotAPIClient(RegionOceania, "API_KEY", mock.NewStatusMockDoer(200), logrus.StandardLogger())
-			_, err := c.put("endpoint", tt.target)
+			err := c.put("endpoint", tt.target)
 			assert.Equal(t, tt.wantErr, err != nil)
 		})
 	}

--- a/mock/mock_doer_test.go
+++ b/mock/mock_doer_test.go
@@ -18,7 +18,7 @@ func TestNewJSONMockDoer(t *testing.T) {
 		args args
 	}{
 		{
-			name: "contruct",
+			name: "construct",
 			args: args{
 				object: struct {
 					Attr int
@@ -64,7 +64,7 @@ func TestNewStatusMockDoer(t *testing.T) {
 		args args
 	}{
 		{
-			name: "contruct",
+			name: "construct",
 			args: args{
 				code: 200,
 			},


### PR DESCRIPTION
The previously used version for the `golangci-lint` command used in the CI is broken for the newest go version. Use the latest docker version instead

Also fixes errors flagged by the linter