### PR TITLE
feat: data dragon caching

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -108,7 +108,7 @@ linters-settings:
     suggest-new: true
   dupl:
     # tokens count to trigger issue, 150 by default
-    threshold: 100
+    threshold: 150
   goconst:
     # minimal length of string constant, 3 by default
     min-len: 3

--- a/model/item.go
+++ b/model/item.go
@@ -2,6 +2,7 @@ package model
 
 // Item represents an item
 type Item struct {
+	ID   string `json:"id"`
 	Name string `json:"name"`
 	Rune struct {
 		IsRune bool   `json:"isrune"`


### PR DESCRIPTION
resolves #5 

lazily loads values for each method upon first call
caches can be reset by calling `ClearCaches`
is thread-safe but might do some duplicated fetches when loading data, due to race conditions, which do not lead to any deadlock scenarios.