### PR TITLE
feat: methods for access to static data

### DIFF
--- a/api/constants.go
+++ b/api/constants.go
@@ -96,6 +96,12 @@ const (
 )
 
 const (
+	staticDataBaseURL                    = "https://static.developer.riotgames.com/docs/lol"
+	staticDataEndpointSeasons            = staticDataBaseURL + "/seasons.json"
+	staticDataEndpointQueues             = staticDataBaseURL + "/queues.json"
+	staticDataEndpointMaps               = staticDataBaseURL + "/maps.json"
+	staticDataEndpointGameModes          = staticDataBaseURL + "/gameModes.json"
+	staticDataEndpointGameTypes          = staticDataBaseURL + "/gameTypes.json"
 	apiURLFormat                         = "%s://%s.%s%s"
 	baseURL                              = "api.riotgames.com"
 	scheme                               = "https"

--- a/api/data_dragon_test.go
+++ b/api/data_dragon_test.go
@@ -14,11 +14,13 @@ import (
 )
 
 func TestNewDataDragonClient(t *testing.T) {
+	t.Parallel()
 	ddClient := NewDataDragonClient(http.DefaultClient, RegionEuropeWest, log.StandardLogger())
 	require.NotNil(t, ddClient)
 }
 
 func TestDataDragonClient_GetChampions(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		doer    Doer
@@ -62,6 +64,7 @@ func TestDataDragonClient_GetChampions(t *testing.T) {
 }
 
 func TestDataDragonClient_GetChampion(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		doer    Doer
@@ -110,6 +113,7 @@ func TestDataDragonClient_GetChampion(t *testing.T) {
 }
 
 func TestDataDragonClient_GetProfileIcons(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		doer    Doer
@@ -153,6 +157,7 @@ func TestDataDragonClient_GetProfileIcons(t *testing.T) {
 }
 
 func TestDataDragonClient_GetItems(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		doer    Doer
@@ -196,6 +201,7 @@ func TestDataDragonClient_GetItems(t *testing.T) {
 }
 
 func TestDataDragonClient_GetRunes(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		doer    Doer
@@ -239,6 +245,7 @@ func TestDataDragonClient_GetRunes(t *testing.T) {
 }
 
 func TestDataDragonClient_GetMasteries(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		doer    Doer
@@ -282,6 +289,7 @@ func TestDataDragonClient_GetMasteries(t *testing.T) {
 }
 
 func TestDataDragonClient_GetSummonerSpells(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		doer    Doer
@@ -325,11 +333,13 @@ func TestDataDragonClient_GetSummonerSpells(t *testing.T) {
 }
 
 func TestDataDragonClient_ClearCaches(t *testing.T) {
+	t.Parallel()
 	c := NewDataDragonClient(http.DefaultClient, RegionKorea, log.StandardLogger())
 	c.ClearCaches()
 }
 
 func TestDataDragonClient_doRequest(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		endpoint string
@@ -365,6 +375,7 @@ func TestDataDragonClient_doRequest(t *testing.T) {
 }
 
 func TestDataDragonClient_init(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		doer    Doer
@@ -393,6 +404,7 @@ func TestDataDragonClient_init(t *testing.T) {
 }
 
 func TestDataDragonClient_getInto(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		target  interface{}
@@ -414,6 +426,7 @@ func TestDataDragonClient_getInto(t *testing.T) {
 }
 
 func Test_versionGreaterThan(t *testing.T) {
+	t.Parallel()
 	type args struct {
 		v1 string
 		v2 string

--- a/api/static_data.go
+++ b/api/static_data.go
@@ -1,0 +1,154 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/KnutZuidema/golio/model"
+)
+
+// StaticDataClient provides access to static data provided by Riot
+// data is fetched on the first call to each method and cached for further calls
+type StaticDataClient struct {
+	logger  logrus.FieldLogger
+	client  Doer
+	mutexes map[string]*sync.RWMutex
+	cache   map[string]interface{}
+}
+
+// NewStaticDataClient returns a new client
+func NewStaticDataClient(doer Doer, logger logrus.FieldLogger) *StaticDataClient {
+	mutexes := map[string]*sync.RWMutex{
+		"seasons":   {},
+		"queues":    {},
+		"maps":      {},
+		"gameModes": {},
+		"gameTypes": {},
+	}
+	return &StaticDataClient{
+		logger:  logger,
+		client:  doer,
+		mutexes: mutexes,
+		cache:   map[string]interface{}{},
+	}
+}
+
+// GetSeasons returns static data for seasons
+func (c *StaticDataClient) GetSeasons() ([]model.Season, error) {
+	mu := c.mutexes["seasons"]
+	unlock, toggle := rwLockToggle(mu)
+	defer unlock()
+	seasons, ok := c.cache["seasons"].([]model.Season)
+	if !ok {
+		toggle()
+		if err := c.getInto(staticDataEndpointSeasons, &seasons); err != nil {
+			return nil, err
+		}
+		c.cache["seasons"] = seasons
+	}
+	res := make([]model.Season, len(seasons))
+	copy(res, seasons)
+	return res, nil
+}
+
+// GetQueues returns static data for queues
+func (c *StaticDataClient) GetQueues() ([]model.Queue, error) {
+	mu := c.mutexes["queues"]
+	unlock, toggle := rwLockToggle(mu)
+	defer unlock()
+	queues, ok := c.cache["queues"].([]model.Queue)
+	if !ok {
+		toggle()
+		if err := c.getInto(staticDataEndpointQueues, &queues); err != nil {
+			return nil, err
+		}
+		c.cache["queues"] = queues
+	}
+	res := make([]model.Queue, len(queues))
+	copy(res, queues)
+	return res, nil
+}
+
+// GetMaps returns static data for maps
+func (c *StaticDataClient) GetMaps() ([]model.Map, error) {
+	mu := c.mutexes["maps"]
+	unlock, toggle := rwLockToggle(mu)
+	defer unlock()
+	maps, ok := c.cache["maps"].([]model.Map)
+	if !ok {
+		toggle()
+		if err := c.getInto(staticDataEndpointMaps, &maps); err != nil {
+			return nil, err
+		}
+		c.cache["maps"] = maps
+	}
+	res := make([]model.Map, len(maps))
+	copy(res, maps)
+	return res, nil
+}
+
+// GetGameModes returns static data for game modes
+func (c *StaticDataClient) GetGameModes() ([]model.GameMode, error) {
+	mu := c.mutexes["gameModes"]
+	unlock, toggle := rwLockToggle(mu)
+	defer unlock()
+	gameModes, ok := c.cache["gameModes"].([]model.GameMode)
+	if !ok {
+		toggle()
+		if err := c.getInto(staticDataEndpointGameModes, &gameModes); err != nil {
+			return nil, err
+		}
+		c.cache["gameModes"] = gameModes
+	}
+	res := make([]model.GameMode, len(gameModes))
+	copy(res, gameModes)
+	return res, nil
+}
+
+// GetGameTypes returns static data for game types
+func (c *StaticDataClient) GetGameTypes() ([]model.GameType, error) {
+	mu := c.mutexes["gameTypes"]
+	unlock, toggle := rwLockToggle(mu)
+	defer unlock()
+	gameTypes, ok := c.cache["gameTypes"].([]model.GameType)
+	if !ok {
+		toggle()
+		if err := c.getInto(staticDataEndpointGameTypes, &gameTypes); err != nil {
+			return nil, err
+		}
+		c.cache["gameTypes"] = gameTypes
+	}
+	res := make([]model.GameType, len(gameTypes))
+	copy(res, gameTypes)
+	return res, nil
+}
+
+// ClearCaches clears caches for all methods
+func (c *StaticDataClient) ClearCaches() {
+	c.cache = map[string]interface{}{}
+}
+
+func (c *StaticDataClient) getInto(endpoint string, target interface{}) error {
+	req, _ := http.NewRequest(http.MethodGet, endpoint, nil)
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		err, ok := StatusToError[resp.StatusCode]
+		if !ok {
+			err = Error{
+				Message:    "unknown error reason",
+				StatusCode: resp.StatusCode,
+			}
+		}
+		return err
+	}
+	if err := json.NewDecoder(resp.Body).Decode(target); err != nil {
+		return err
+	}
+	return nil
+}

--- a/api/static_data_test.go
+++ b/api/static_data_test.go
@@ -1,0 +1,261 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/KnutZuidema/golio/mock"
+	"github.com/KnutZuidema/golio/model"
+)
+
+func TestStaticDataClient_GetSeasons(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		doer    Doer
+		want    []model.Season
+		wantErr error
+	}{
+		{
+			name: "get response",
+			doer: mock.NewJSONMockDoer([]model.Season{{}}, 200),
+			want: []model.Season{{}},
+		},
+		{
+			name:    "known error",
+			doer:    mock.NewStatusMockDoer(http.StatusForbidden),
+			wantErr: ErrForbidden,
+		},
+		{
+			name: "unknown error",
+			doer: mock.NewStatusMockDoer(999),
+			wantErr: Error{
+				Message:    "unknown error reason",
+				StatusCode: 999,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewStaticDataClient(tt.doer, log.StandardLogger())
+			got, err := c.GetSeasons()
+			assert.Equal(t, tt.wantErr, err)
+			if tt.wantErr == nil {
+				assert.Equal(t, tt.want, got)
+				got, err := c.GetSeasons()
+				assert.Nil(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestStaticDataClient_GetQueues(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		doer    Doer
+		want    []model.Queue
+		wantErr error
+	}{
+		{
+			name: "get response",
+			doer: mock.NewJSONMockDoer([]model.Queue{{}}, 200),
+			want: []model.Queue{{}},
+		},
+		{
+			name:    "known error",
+			doer:    mock.NewStatusMockDoer(http.StatusForbidden),
+			wantErr: ErrForbidden,
+		},
+		{
+			name: "unknown error",
+			doer: mock.NewStatusMockDoer(999),
+			wantErr: Error{
+				Message:    "unknown error reason",
+				StatusCode: 999,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewStaticDataClient(tt.doer, log.StandardLogger())
+			got, err := c.GetQueues()
+			assert.Equal(t, tt.wantErr, err)
+			if tt.wantErr == nil {
+				assert.Equal(t, tt.want, got)
+				got, err := c.GetQueues()
+				assert.Nil(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestStaticDataClient_GetMaps(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		doer    Doer
+		want    []model.Map
+		wantErr error
+	}{
+		{
+			name: "get response",
+			doer: mock.NewJSONMockDoer([]model.Map{{}}, 200),
+			want: []model.Map{{}},
+		},
+		{
+			name:    "known error",
+			doer:    mock.NewStatusMockDoer(http.StatusForbidden),
+			wantErr: ErrForbidden,
+		},
+		{
+			name: "unknown error",
+			doer: mock.NewStatusMockDoer(999),
+			wantErr: Error{
+				Message:    "unknown error reason",
+				StatusCode: 999,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewStaticDataClient(tt.doer, log.StandardLogger())
+			got, err := c.GetMaps()
+			assert.Equal(t, tt.wantErr, err)
+			if tt.wantErr == nil {
+				assert.Equal(t, tt.want, got)
+				got, err := c.GetMaps()
+				assert.Nil(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestStaticDataClient_GetGameModes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		doer    Doer
+		want    []model.GameMode
+		wantErr error
+	}{
+		{
+			name: "get response",
+			doer: mock.NewJSONMockDoer([]model.GameMode{{}}, 200),
+			want: []model.GameMode{{}},
+		},
+		{
+			name:    "known error",
+			doer:    mock.NewStatusMockDoer(http.StatusForbidden),
+			wantErr: ErrForbidden,
+		},
+		{
+			name: "unknown error",
+			doer: mock.NewStatusMockDoer(999),
+			wantErr: Error{
+				Message:    "unknown error reason",
+				StatusCode: 999,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewStaticDataClient(tt.doer, log.StandardLogger())
+			got, err := c.GetGameModes()
+			assert.Equal(t, tt.wantErr, err)
+			if tt.wantErr == nil {
+				assert.Equal(t, tt.want, got)
+				got, err := c.GetGameModes()
+				assert.Nil(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestStaticDataClient_GetGameTypes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		doer    Doer
+		want    []model.GameType
+		wantErr error
+	}{
+		{
+			name: "get response",
+			doer: mock.NewJSONMockDoer([]model.GameType{{}}, 200),
+			want: []model.GameType{{}},
+		},
+		{
+			name:    "known error",
+			doer:    mock.NewStatusMockDoer(http.StatusForbidden),
+			wantErr: ErrForbidden,
+		},
+		{
+			name: "unknown error",
+			doer: mock.NewStatusMockDoer(999),
+			wantErr: Error{
+				Message:    "unknown error reason",
+				StatusCode: 999,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewStaticDataClient(tt.doer, log.StandardLogger())
+			got, err := c.GetGameTypes()
+			assert.Equal(t, tt.wantErr, err)
+			if tt.wantErr == nil {
+				assert.Equal(t, tt.want, got)
+				got, err := c.GetGameTypes()
+				assert.Nil(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestStaticDataClient_getInto(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		target  interface{}
+		doer    Doer
+		wantErr bool
+	}{
+		{
+			name: "fail do",
+			doer: &mock.Doer{
+				Custom: func(r *http.Request) (*http.Response, error) {
+					return nil, fmt.Errorf("error")
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:    "fail decode",
+			target:  failJSONDecoding{},
+			doer:    mock.NewJSONMockDoer(0, 200),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewStaticDataClient(tt.doer, log.StandardLogger())
+			err := c.getInto("endpoint", tt.target)
+			assert.Equal(t, tt.wantErr, err != nil)
+		})
+	}
+}
+
+func TestStaticDataClient_ClearCaches(t *testing.T) {
+	client := NewStaticDataClient(http.DefaultClient, log.StandardLogger())
+	client.ClearCaches()
+}

--- a/golio.go
+++ b/golio.go
@@ -30,6 +30,7 @@ import (
 type Client struct {
 	*api.RiotAPIClient
 	*api.DataDragonClient
+	*api.StaticDataClient
 }
 
 // NewClient returns a new client for both the Riot API and the Data Dragon service
@@ -37,5 +38,6 @@ func NewClient(region api.Region, apiKey string, client api.Doer, logger log.Fie
 	return &Client{
 		RiotAPIClient:    api.NewRiotAPIClient(region, apiKey, client, logger),
 		DataDragonClient: api.NewDataDragonClient(client, region, logger),
+		StaticDataClient: api.NewStaticDataClient(client, logger),
 	}
 }

--- a/model/static_data.go
+++ b/model/static_data.go
@@ -1,0 +1,34 @@
+package model
+
+// Season contains an ID and a name for a season
+type Season struct {
+	ID     int    `json:"id"`
+	Season string `json:"season"`
+}
+
+// Queue contains a description and notes, and ID and a map for a queue
+type Queue struct {
+	ID          int    `json:"queueId"`
+	Map         string `json:"map"`
+	Description string `json:"description"`
+	Notes       string `json:"notes"`
+}
+
+// Map contains notes, an ID and a name for a map
+type Map struct {
+	ID    int    `json:"mapId"`
+	Name  string `json:"mapName"`
+	Notes string `json:"notes"`
+}
+
+// GameMode contains a description and name of a game mode
+type GameMode struct {
+	Mode        string `json:"gameMode"`
+	Description string `json:"description"`
+}
+
+// GameType contains a description and name of a game type
+type GameType struct {
+	Type        string `json:"gameType"`
+	Description string `json:"description"`
+}


### PR DESCRIPTION
Riot provides static data, like queue ID mappings. This adds a client with methods to access those endpoints and cache their results