### PR TITLE
fix(api): LeagueItem to include tier attribute

### DIFF
--- a/riot/model.go
+++ b/riot/model.go
@@ -97,6 +97,7 @@ type LeagueItem struct {
 	Losses       int         `json:"losses"`
 	FreshBlood   bool        `json:"freshBlood"`
 	Inactive     bool        `json:"inactive"`
+	Tier         string      `json:"tier"`
 	Rank         string      `json:"rank"`
 	SummonerID   string      `json:"summonerId"`
 	LeaguePoints int         `json:"leaguePoints"`


### PR DESCRIPTION
Missing an attribute as part of the default Riot API. Useful for lookup a player's tier and rank (e.g. Gold III) via `Riot.League.ListBySummoner`.