### PR TITLE
fix json field for frameInterval

### DIFF
--- a/riot/lol/model.go
+++ b/riot/lol/model.go
@@ -531,7 +531,7 @@ func (r *MatchReference) GetGame(client *Client) (*Match, error) {
 // MatchTimeline contains timeline frames for a match
 type MatchTimeline struct {
 	Frames   []*MatchFrame `json:"frames"`
-	Interval int           `json:"interval"`
+	Interval int           `json:"frameInterval"`
 }
 
 // MatchFrame is a single frame in the timeline of a game


### PR DESCRIPTION
[MatchTimelineDto](https://developer.riotgames.com/apis#match-v4/GET_getMatchTimeline) interval field must have changed to `frameInterval`.