### PR TITLE
Fix parameters to query to GetTimeline based on documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.17
       - uses: actions/checkout@v2
       - run: go mod download
       - run: go build .

--- a/riot/lol/match.go
+++ b/riot/lol/match.go
@@ -131,10 +131,10 @@ func (m *MatchClient) ListStream(puuid string, options ...*MatchListOptions) <-c
 // GetTimeline returns the timeline for the given match
 // NOTE: timelines are not available for every match
 // TODO: update to v5 when struct is documented
-func (m *MatchClient) GetTimeline(matchID int) (*MatchTimeline, error) {
+func (m *MatchClient) GetTimeline(id string) (*MatchTimeline, error) {
 	logger := m.logger().WithField("method", "GetTimeline")
 	var timeline MatchTimeline
-	if err := m.c.GetInto(fmt.Sprintf(endpointGetMatchTimeline, fmt.Sprint(matchID)), &timeline); err != nil {
+	if err := m.c.GetInto(fmt.Sprintf(endpointGetMatchTimeline, id), &timeline); err != nil {
 		logger.Debug(err)
 		return nil, err
 	}

--- a/riot/lol/match_test.go
+++ b/riot/lol/match_test.go
@@ -155,7 +155,7 @@ func TestMatchClient_GetTimeline(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client := internal.NewClient(api.RegionEuropeWest, "API_KEY", tt.doer, logrus.StandardLogger())
-			got, err := (&MatchClient{c: client}).GetTimeline(0)
+			got, err := (&MatchClient{c: client}).GetTimeline("0")
 			require.Equal(t, err, tt.wantErr, fmt.Sprintf("want err %v, got %v", tt.wantErr, err))
 			if tt.wantErr == nil {
 				assert.Equal(t, got, tt.want)


### PR DESCRIPTION
I noticed an error in the Query to collect a Match Timeline. It required a MatchId which is a string and not an integer. 

See official documentation : https://developer.riotgames.com/apis#match-v5/GET_getTimeline 