### PR TITLE
[Golio]<feat>: Add Account Client + Marked SumV4 by name as Deprecated

### DIFF
--- a/riot/account/account.go
+++ b/riot/account/account.go
@@ -1,0 +1,54 @@
+package account
+
+import (
+	"fmt"
+
+	"github.com/KnutZuidema/golio/api"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/KnutZuidema/golio/internal"
+)
+
+// AccountClient provides methods for the account endpoints of the League of Legends API.
+type AccountClient struct { //nolint:golint
+	c *internal.Client
+}
+
+// GetByPUUID returns the account matching the PUUID
+func (ac *AccountClient) GetByPUUID(puuid string) (*Account, error) {
+	logger := ac.logger().WithField("method", "GetByPUUID")
+	var account Account
+	c := *ac.c
+	c.Region = api.Region(api.RegionToRoute[c.Region])
+
+	if err := c.GetInto(
+		fmt.Sprintf(endpointGetByPUUID, puuid),
+		&account,
+	); err != nil {
+		logger.Debug(err)
+		return nil, err
+	}
+	return &account, nil
+}
+
+// GetByRiotID returns the account matching the riot id
+func (ac *AccountClient) GetByRiotID(gameName, tagLine string) (*Account, error) {
+	logger := ac.logger().WithField("method", "GetByRiotID")
+	var account Account
+	c := *ac.c
+	c.Region = api.Region(api.RegionToRoute[c.Region])
+
+	if err := c.GetInto(
+		fmt.Sprintf(endpointGetByRiotID, gameName, tagLine),
+		&account,
+	); err != nil {
+		logger.Debug(err)
+		return nil, err
+	}
+	return &account, nil
+}
+
+func (ac *AccountClient) logger() log.FieldLogger {
+	return ac.c.Logger().WithField("category", "account")
+}

--- a/riot/account/account_test.go
+++ b/riot/account/account_test.go
@@ -1,0 +1,81 @@
+package account
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KnutZuidema/golio/api"
+	"github.com/KnutZuidema/golio/internal"
+	"github.com/KnutZuidema/golio/internal/mock"
+)
+
+func TestAccountClient_GetByPUUID(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		want    *Account
+		doer    internal.Doer
+		wantErr error
+	}{
+		{
+			name: "get response",
+			want: &Account{},
+			doer: mock.NewJSONMockDoer(Account{}, 200),
+		},
+		{
+			name:    "not found",
+			wantErr: api.ErrNotFound,
+			doer:    mock.NewStatusMockDoer(http.StatusNotFound),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				client := internal.NewClient(api.RegionEuropeWest, "API_KEY", tt.doer, logrus.StandardLogger())
+				got, err := (&AccountClient{c: client}).GetByPUUID("")
+				require.Equal(t, err, tt.wantErr, fmt.Sprintf("want err %v, got %v", tt.wantErr, err))
+				if tt.wantErr == nil {
+					assert.Equal(t, got, tt.want)
+				}
+			},
+		)
+	}
+}
+
+func TestAccountClient_GetByRiotID(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		want    *Account
+		doer    internal.Doer
+		wantErr error
+	}{
+		{
+			name: "get response",
+			want: &Account{},
+			doer: mock.NewJSONMockDoer(Account{}, 200),
+		},
+		{
+			name:    "not found",
+			wantErr: api.ErrNotFound,
+			doer:    mock.NewStatusMockDoer(http.StatusNotFound),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				client := internal.NewClient(api.RegionEuropeWest, "API_KEY", tt.doer, logrus.StandardLogger())
+				got, err := (&AccountClient{c: client}).GetByRiotID("", "")
+				require.Equal(t, err, tt.wantErr, fmt.Sprintf("want err %v, got %v", tt.wantErr, err))
+				if tt.wantErr == nil {
+					assert.Equal(t, got, tt.want)
+				}
+			},
+		)
+	}
+}

--- a/riot/account/client.go
+++ b/riot/account/client.go
@@ -1,0 +1,15 @@
+package account
+
+import "github.com/KnutZuidema/golio/internal"
+
+// Client pools all methods for endpoints of the League of Legends API.
+type Client struct {
+	AccountClient *AccountClient
+}
+
+// NewClient returns a new instance of a League of Legends client.
+func NewClient(base *internal.Client) *Client {
+	return &Client{
+		AccountClient: &AccountClient{base},
+	}
+}

--- a/riot/account/client_test.go
+++ b/riot/account/client_test.go
@@ -1,0 +1,18 @@
+package account
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/KnutZuidema/golio/api"
+	"github.com/KnutZuidema/golio/internal"
+	"github.com/KnutZuidema/golio/internal/mock"
+)
+
+func TestNewClient(t *testing.T) {
+	c := NewClient(internal.NewClient(api.RegionBrasil, "key", mock.NewStatusMockDoer(200), logrus.StandardLogger()))
+	if c == nil {
+		t.Error("returned nil")
+	}
+}

--- a/riot/account/constants.go
+++ b/riot/account/constants.go
@@ -1,0 +1,9 @@
+package account
+
+const (
+	endpointBase         = "/riot"
+	endpointAccountBase  = endpointBase + "/account/v1"
+	endpointAccountsBase = endpointAccountBase + "/accounts"
+	endpointGetByPUUID   = endpointAccountsBase + "/by-puuid/%s"
+	endpointGetByRiotID  = endpointAccountsBase + "/by-riot-id/%s/%s"
+)

--- a/riot/account/model.go
+++ b/riot/account/model.go
@@ -1,0 +1,8 @@
+package account
+
+// Account contains information about a user account
+type Account struct {
+	Puuid    string `json:"puuid"`
+	GameName string `json:"gameName"`
+	TagLine  string `json:"tagLine"`
+}

--- a/riot/lol/summoner.go
+++ b/riot/lol/summoner.go
@@ -14,6 +14,8 @@ type SummonerClient struct {
 }
 
 // GetByName returns the summoner with the given summoner name
+//
+// Deprecated: Riot has marked this endpoint as deprecated and it will be eventually removed in the future.
 func (s *SummonerClient) GetByName(name string) (*Summoner, error) {
 	return s.getBy(identificationName, name, s.logger().WithField("method", "GetByName"))
 }


### PR DESCRIPTION
- Implemented Account Client from #60 
- Removed `refactor: test response body` commit 
- Marked `(s *SummonerClient) GetByName(name string)` as deprecated