### PR TITLE
Migrate to Spectator v5

### DIFF
--- a/riot/lol/constants.go
+++ b/riot/lol/constants.go
@@ -35,7 +35,7 @@ const (
 	endpointSummonerBase                       = endpointBase + "/summoner/v4"
 	endpointGetSummonerBySummonerID            = endpointSummonerBase + "/summoners/%s"
 	endpointGetSummonerBy                      = endpointSummonerBase + "/summoners/by-%s/%s"
-	endpointSpectatorBase                      = endpointBase + "/spectator/v4"
+	endpointSpectatorBase                      = endpointBase + "/spectator/v5"
 	endpointGetCurrentGame                     = endpointSpectatorBase + "/active-games/by-summoner/%s"
 	endpointGetFeaturedGames                   = endpointSpectatorBase + "/featured-games"
 	endpointTournamentStubBase                 = endpointBase + "/tournament-stub/v4"

--- a/riot/lol/model.go
+++ b/riot/lol/model.go
@@ -604,6 +604,7 @@ type CurrentGameParticipant struct {
 	Spell1ID                 int                        `json:"spell1Id"`
 	TeamID                   int                        `json:"teamId"`
 	SummonerID               string                     `json:"summonerId"`
+	PUUID                    string                     `json:"puuid"`
 }
 
 // GetChampion returns the champion played by this participant

--- a/riot/lol/spectator.go
+++ b/riot/lol/spectator.go
@@ -14,10 +14,10 @@ type SpectatorClient struct {
 }
 
 // GetCurrent returns a currently running game for a summoner
-func (s *SpectatorClient) GetCurrent(summonerID string) (*GameInfo, error) {
+func (s *SpectatorClient) GetCurrent(puuid string) (*GameInfo, error) {
 	logger := s.logger().WithField("method", "GetCurrent")
 	var games GameInfo
-	if err := s.c.GetInto(fmt.Sprintf(endpointGetCurrentGame, summonerID), &games); err != nil {
+	if err := s.c.GetInto(fmt.Sprintf(endpointGetCurrentGame, puuid), &games); err != nil {
 		logger.Debug(err)
 		return nil, err
 	}


### PR DESCRIPTION
Riot has deprecated the Spectator v4 endpoint and it doesn't seem to work anymore