### PR TITLE
Fix static champion by ID

### DIFF
--- a/datadragon/data_dragon.go
+++ b/datadragon/data_dragon.go
@@ -130,7 +130,7 @@ func (c *Client) GetChampionByID(id string) (ChampionDataExtended, error) {
 	}
 	for _, champion := range champions {
 		if champion.Key == id {
-			return c.GetChampion(champion.Name)
+			return c.GetChampion(champion.ID)
 		}
 	}
 	return ChampionDataExtended{}, api.ErrNotFound

--- a/datadragon/data_dragon_test.go
+++ b/datadragon/data_dragon_test.go
@@ -78,12 +78,42 @@ func TestClient_GetChampion(t *testing.T) {
 	}{
 		{
 			name: "get response",
-			doer: dataDragonResponseDoer(
-				map[string]ChampionDataExtended{
-					"champion": {},
+			doer: mock.NewPathJSONMockDoer(
+				[]mock.PathJSONResponse{
+					{
+						PathSuffix: "/champion.json",
+						Object: dataDragonResponse{
+							Data: map[string]ChampionData{
+								"champion-id": {
+									ID:   "champion-id",
+									Name: "champion-name",
+								},
+							},
+						},
+						Code: 200,
+					},
+					{
+						PathSuffix: "/champion/champion-id.json",
+						Object: dataDragonResponse{
+							Data: map[string]ChampionDataExtended{
+								"champion-id": {
+									ChampionData: ChampionData{
+										ID:   "champion-id",
+										Name: "champion-name",
+									},
+								},
+							},
+						},
+						Code: 200,
+					},
 				},
 			),
-			want: ChampionDataExtended{},
+			want: ChampionDataExtended{
+				ChampionData: ChampionData{
+					ID:   "champion-id",
+					Name: "champion-name",
+				},
+			},
 		},
 		{
 			name:    "not found",
@@ -108,11 +138,11 @@ func TestClient_GetChampion(t *testing.T) {
 		t.Run(
 			tt.name, func(t *testing.T) {
 				c := NewClient(tt.doer, api.RegionEuropeWest, log.StandardLogger())
-				got, err := c.GetChampion("champion")
+				got, err := c.GetChampion("champion-name")
 				assert.Equal(t, tt.wantErr, err)
 				if tt.wantErr == nil {
 					assert.Equal(t, tt.want, got)
-					got, err := c.GetChampion("champion")
+					got, err := c.GetChampion("champion-name")
 					assert.Nil(t, err)
 					assert.Equal(t, tt.want, got)
 				}
@@ -380,11 +410,17 @@ func TestClient_GetChampionByID(t *testing.T) {
 			name: "get response",
 			doer: dataDragonResponseDoer(
 				map[string]ChampionData{
-					"champion": {Name: "champion", Key: "id"},
+					"champion-id": {ID: "champion-id", Name: "champion-name", Key: "champion-id"},
 				},
 			),
-			id:   "id",
-			want: ChampionDataExtended{ChampionData: ChampionData{Name: "champion", Key: "id"}},
+			id: "champion-id",
+			want: ChampionDataExtended{
+				ChampionData: ChampionData{
+					ID:   "champion-id",
+					Name: "champion-name",
+					Key:  "champion-id",
+				},
+			},
 		},
 		{
 			name:    "not found",

--- a/datadragon/model_test.go
+++ b/datadragon/model_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/KnutZuidema/golio/api"
 	"github.com/KnutZuidema/golio/internal"
+	"github.com/KnutZuidema/golio/internal/mock"
 )
 
 func TestChampionData_GetExtended(t *testing.T) {
@@ -21,13 +22,38 @@ func TestChampionData_GetExtended(t *testing.T) {
 	tests := []test{
 		{
 			name: "valid",
-			doer: dataDragonResponseDoer(
-				map[string]*ChampionDataExtended{
-					"champion": {ChampionData: ChampionData{Name: "champion"}},
+			doer: mock.NewPathJSONMockDoer(
+				[]mock.PathJSONResponse{
+					{
+						PathSuffix: "/champion.json",
+						Object: dataDragonResponse{
+							Data: map[string]ChampionData{
+								"champion-id": {
+									ID:   "champion-id",
+									Name: "champion-name",
+								},
+							},
+						},
+						Code: 200,
+					},
+					{
+						PathSuffix: "/champion/champion-id.json",
+						Object: dataDragonResponse{
+							Data: map[string]ChampionDataExtended{
+								"champion-id": {
+									ChampionData: ChampionData{
+										ID:   "champion-id",
+										Name: "champion-name",
+									},
+								},
+							},
+						},
+						Code: 200,
+					},
 				},
 			),
-			data: &ChampionData{Name: "champion"},
-			want: ChampionDataExtended{ChampionData: ChampionData{Name: "champion"}},
+			data: &ChampionData{ID: "champion-id", Name: "champion-name"},
+			want: ChampionDataExtended{ChampionData: ChampionData{ID: "champion-id", Name: "champion-name"}},
 		},
 	}
 	for _, test := range tests {

--- a/riot/lol/model_test.go
+++ b/riot/lol/model_test.go
@@ -62,16 +62,16 @@ func TestChampionInfo_GetChampionsForNewPlayers(t *testing.T) {
 			name: "valid",
 			doer: dataDragonResponseDoer(
 				map[string]datadragon.ChampionData{
-					"champion1": {Key: "1", Name: "champion1"},
-					"champion2": {Key: "2", Name: "champion2"},
+					"1": {Key: "1", ID: "1", Name: "champion1"},
+					"2": {Key: "2", ID: "2", Name: "champion2"},
 				},
 			),
 			model: ChampionInfo{
 				FreeChampionIDsForNewPlayers: []int{1, 2},
 			},
 			want: []datadragon.ChampionDataExtended{
-				{ChampionData: datadragon.ChampionData{Name: "champion1", Key: "1"}},
-				{ChampionData: datadragon.ChampionData{Name: "champion2", Key: "2"}},
+				{ChampionData: datadragon.ChampionData{ID: "1", Name: "champion1", Key: "1"}},
+				{ChampionData: datadragon.ChampionData{ID: "2", Name: "champion2", Key: "2"}},
 			},
 		},
 		{
@@ -111,16 +111,16 @@ func TestChampionInfo_GetChampions(t *testing.T) {
 			name: "valid",
 			doer: dataDragonResponseDoer(
 				map[string]datadragon.ChampionData{
-					"champion1": {Key: "1", Name: "champion1"},
-					"champion2": {Key: "2", Name: "champion2"},
+					"1": {Key: "1", ID: "1", Name: "champion1"},
+					"2": {Key: "2", ID: "2", Name: "champion2"},
 				},
 			),
 			model: ChampionInfo{
 				FreeChampionIDs: []int{1, 2},
 			},
 			want: []datadragon.ChampionDataExtended{
-				{ChampionData: datadragon.ChampionData{Name: "champion1", Key: "1"}},
-				{ChampionData: datadragon.ChampionData{Name: "champion2", Key: "2"}},
+				{ChampionData: datadragon.ChampionData{ID: "1", Name: "champion1", Key: "1"}},
+				{ChampionData: datadragon.ChampionData{ID: "2", Name: "champion2", Key: "2"}},
 			},
 		},
 		{
@@ -188,11 +188,13 @@ func TestChampionMastery_GetChampion(t *testing.T) {
 			name: "valid",
 			doer: dataDragonResponseDoer(
 				map[string]datadragon.ChampionData{
-					"champion": {Name: "champion", Key: "1"},
+					"1": {Key: "1", ID: "1", Name: "champion"},
 				},
 			),
 			model: ChampionMastery{ChampionID: 1},
-			want:  datadragon.ChampionDataExtended{ChampionData: datadragon.ChampionData{Name: "champion", Key: "1"}},
+			want: datadragon.ChampionDataExtended{
+				ChampionData: datadragon.ChampionData{ID: "1", Name: "champion", Key: "1"},
+			},
 		},
 	}
 	for _, test := range tests {
@@ -420,11 +422,13 @@ func TestTeamBan_GetChampion(t *testing.T) {
 			name: "valid",
 			doer: dataDragonResponseDoer(
 				map[string]datadragon.ChampionData{
-					"champion": {Name: "champion", Key: "1"},
+					"1": {Key: "1", ID: "1", Name: "champion"},
 				},
 			),
 			model: TeamBan{ChampionID: 1},
-			want:  datadragon.ChampionDataExtended{ChampionData: datadragon.ChampionData{Name: "champion", Key: "1"}},
+			want: datadragon.ChampionDataExtended{
+				ChampionData: datadragon.ChampionData{ID: "1", Name: "champion", Key: "1"},
+			},
 		},
 	}
 	for _, test := range tests {
@@ -452,11 +456,13 @@ func TestParticipant_GetChampion(t *testing.T) {
 			name: "valid",
 			doer: dataDragonResponseDoer(
 				map[string]datadragon.ChampionData{
-					"champion": {Name: "champion", Key: "1"},
+					"1": {Key: "1", ID: "1", Name: "champion"},
 				},
 			),
 			model: Participant{ChampionID: 1},
-			want:  datadragon.ChampionDataExtended{ChampionData: datadragon.ChampionData{Name: "champion", Key: "1"}},
+			want: datadragon.ChampionDataExtended{
+				ChampionData: datadragon.ChampionData{ID: "1", Name: "champion", Key: "1"},
+			},
 		},
 	}
 	for _, test := range tests {
@@ -772,11 +778,13 @@ func TestBannedChampion_GetChampion(t *testing.T) {
 			name: "valid",
 			doer: dataDragonResponseDoer(
 				map[string]datadragon.ChampionData{
-					"champion": {Name: "champion", Key: "1"},
+					"1": {Key: "1", ID: "1", Name: "champion"},
 				},
 			),
 			model: BannedChampion{ChampionID: 1},
-			want:  datadragon.ChampionDataExtended{ChampionData: datadragon.ChampionData{Name: "champion", Key: "1"}},
+			want: datadragon.ChampionDataExtended{
+				ChampionData: datadragon.ChampionData{ID: "1", Name: "champion", Key: "1"},
+			},
 		},
 	}
 	for _, test := range tests {
@@ -804,11 +812,13 @@ func TestCurrentGameParticipant_GetChampion(t *testing.T) {
 			name: "valid",
 			doer: dataDragonResponseDoer(
 				map[string]datadragon.ChampionData{
-					"champion": {Name: "champion", Key: "1"},
+					"1": {Key: "1", ID: "1", Name: "champion"},
 				},
 			),
 			model: CurrentGameParticipant{ChampionID: 1},
-			want:  datadragon.ChampionDataExtended{ChampionData: datadragon.ChampionData{Name: "champion", Key: "1"}},
+			want: datadragon.ChampionDataExtended{
+				ChampionData: datadragon.ChampionData{ID: "1", Name: "champion", Key: "1"},
+			},
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
Changes:
- Use ID instead of name to fetch static champion info from DataDragon (e.g. https://ddragon.leagueoflegends.com/cdn/14.8.1/data/en_GB/champion/Wukong.json (403 Forbidden) -> https://ddragon.leagueoflegends.com/cdn/14.8.1/data/en_GB/champion/MonkeyKing.json)