### PR TITLE
Removed non-existent fields for the summoner name.

### DIFF
--- a/riot/lol/constants.go
+++ b/riot/lol/constants.go
@@ -57,9 +57,9 @@ type identification string
 
 const (
 	identificationName       identification = "name"
-	identificationAccountID                 = "account"
-	identificationPUUID                     = "puuid"
-	identificationSummonerID                = "summonerID"
+	identificationAccountID  identification = "account"
+	identificationPUUID      identification = "puuid"
+	identificationSummonerID identification = "summonerID"
 )
 
 type queue string
@@ -67,8 +67,8 @@ type queue string
 // All possible queues
 const (
 	QueueRankedSolo            queue = "RANKED_SOLO_5x5"
-	QueueRankedFlex                  = "RANKED_FLEX_SR"
-	QueueRankedTwistedTreeline       = "RANKED_FLEX_TT"
+	QueueRankedFlex            queue = "RANKED_FLEX_SR"
+	QueueRankedTwistedTreeline queue = "RANKED_FLEX_TT"
 )
 
 type tier string
@@ -76,15 +76,15 @@ type tier string
 // All possible Tiers
 const (
 	TierIron        tier = "IRON"
-	TierBronze           = "BRONZE"
-	TierSilver           = "SILVER"
-	TierGold             = "GOLD"
-	TierPlatinum         = "PLATINUM"
-	TierEmerald          = "EMERALD"
-	TierDiamond          = "DIAMOND"
-	TierMaster           = "MASTER"
-	TierGrandMaster      = "GRANDMASTER"
-	TierChallenger       = "CHALLENGER"
+	TierBronze      tier = "BRONZE"
+	TierSilver      tier = "SILVER"
+	TierGold        tier = "GOLD"
+	TierPlatinum    tier = "PLATINUM"
+	TierEmerald     tier = "EMERALD"
+	TierDiamond     tier = "DIAMOND"
+	TierMaster      tier = "MASTER"
+	TierGrandMaster tier = "GRANDMASTER"
+	TierChallenger  tier = "CHALLENGER"
 )
 
 type division string
@@ -92,9 +92,9 @@ type division string
 // All possible divisions
 const (
 	DivisionOne   division = "I"
-	DivisionTwo            = "II"
-	DivisionThree          = "III"
-	DivisionFour           = "IV"
+	DivisionTwo   division = "II"
+	DivisionThree division = "III"
+	DivisionFour  division = "IV"
 )
 
 var (

--- a/riot/lol/model.go
+++ b/riot/lol/model.go
@@ -484,18 +484,18 @@ type MatchEventType string
 // All legal value for match event types
 const (
 	MatchEventTypeChampionKill     MatchEventType = "CHAMPION_KILL"
-	MatchEventTypeWardPlaced                      = "WARD_PLACED"
-	MatchEventTypeWardKill                        = "WARD_KILL"
-	MatchEventTypeBuildingKill                    = "BUILDING_KILL"
-	MatchEventTypeEliteMonsterKill                = "ELITE_MONSTER_KILL"
-	MatchEventTypeItemPurchased                   = "ITEM_PURCHASED"
-	MatchEventTypeItemSold                        = "ITEM_SOLD"
-	MatchEventTypeItemDestroyed                   = "ITEM_DESTROYED"
-	MatchEventTypeItemUndo                        = "ITEM_UNDO"
-	MatchEventTypeSkillLevelUp                    = "SKILL_LEVEL_UP"
-	MatchEventTypeAscendedEvent                   = "ASCENDED_EVENT"
-	MatchEventTypeCapturePoint                    = "CAPTURE_POINT"
-	MatchEventTypePoroKingSummon                  = "PORO_KING_SUMMON"
+	MatchEventTypeWardPlaced       MatchEventType = "WARD_PLACED"
+	MatchEventTypeWardKill         MatchEventType = "WARD_KILL"
+	MatchEventTypeBuildingKill     MatchEventType = "BUILDING_KILL"
+	MatchEventTypeEliteMonsterKill MatchEventType = "ELITE_MONSTER_KILL"
+	MatchEventTypeItemPurchased    MatchEventType = "ITEM_PURCHASED"
+	MatchEventTypeItemSold         MatchEventType = "ITEM_SOLD"
+	MatchEventTypeItemDestroyed    MatchEventType = "ITEM_DESTROYED"
+	MatchEventTypeItemUndo         MatchEventType = "ITEM_UNDO"
+	MatchEventTypeSkillLevelUp     MatchEventType = "SKILL_LEVEL_UP"
+	MatchEventTypeAscendedEvent    MatchEventType = "ASCENDED_EVENT"
+	MatchEventTypeCapturePoint     MatchEventType = "CAPTURE_POINT"
+	MatchEventTypePoroKingSummon   MatchEventType = "PORO_KING_SUMMON"
 )
 
 var (

--- a/riot/lol/model.go
+++ b/riot/lol/model.go
@@ -596,7 +596,6 @@ type Observer struct {
 type CurrentGameParticipant struct {
 	ProfileIconID            int                        `json:"profileIconId"`
 	ChampionID               int                        `json:"championId"`
-	SummonerName             string                     `json:"summonerName"`
 	GameCustomizationObjects []*GameCustomizationObject `json:"gameCustomizationObjects"`
 	Bot                      bool                       `json:"bot"`
 	Perks                    *Perks                     `json:"perks"`
@@ -688,7 +687,6 @@ type StatusTranslation struct {
 // Summoner represents a summoner with several related IDs
 type Summoner struct {
 	ProfileIconID int    `json:"profileIconId"`
-	Name          string `json:"name"`
 	PUUID         string `json:"puuid"`
 	SummonerLevel int    `json:"summonerLevel"`
 	RevisionDate  int    `json:"revisionDate"`

--- a/riot/lol/summoner.go
+++ b/riot/lol/summoner.go
@@ -13,11 +13,6 @@ type SummonerClient struct {
 	c *internal.Client
 }
 
-// GetByName returns the summoner with the given summoner name
-func (s *SummonerClient) GetByName(name string) (*Summoner, error) {
-	return s.getBy(identificationName, name, s.logger().WithField("method", "GetByName"))
-}
-
 // GetByAccountID returns the summoner with the given account ID
 func (s *SummonerClient) GetByAccountID(id string) (*Summoner, error) {
 	return s.getBy(identificationAccountID, id, s.logger().WithField("method", "GetByAccountID"))

--- a/riot/lol/summoner_test.go
+++ b/riot/lol/summoner_test.go
@@ -12,40 +12,6 @@ import (
 	"github.com/KnutZuidema/golio/internal/mock"
 )
 
-func TestSummonerClient_GetByName(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name    string
-		doer    internal.Doer
-		want    *Summoner
-		wantErr error
-	}{
-		{
-			name: "get response",
-			want: &Summoner{},
-			doer: mock.NewJSONMockDoer(&Summoner{}, 200),
-		},
-		{
-			name:    "not found",
-			wantErr: api.ErrNotFound,
-			doer:    mock.NewStatusMockDoer(http.StatusNotFound),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(
-			tt.name, func(t *testing.T) {
-				var err error
-				client := internal.NewClient(api.RegionEuropeWest, "API_KEY", tt.doer, logrus.StandardLogger())
-				got, err := (&SummonerClient{c: client}).GetByName("name")
-				assert.Equal(t, err, tt.wantErr)
-				if tt.wantErr == nil {
-					assert.Equal(t, got, tt.want)
-				}
-			},
-		)
-	}
-}
-
 func TestSummonerClient_GetByAccountID(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
This PR removes the non-existent summoner name fields that became obsolete after updating to Spectator v5 and Summoner v4.

See the return signatures here:
https://developer.riotgames.com/apis#spectator-v5

https://developer.riotgames.com/apis#summoner-v4