### PR TITLE
Implement the `ChampionByKey` function and fix a bug related to fetching the champion data from spectator participant.

### DIFF
--- a/datadragon/data_dragon.go
+++ b/datadragon/data_dragon.go
@@ -142,7 +142,7 @@ func (c *Client) GetChampionByID(id string) (ChampionDataExtended, error) {
 	return champion, nil
 }
 
-// GetChampion returns information about the champion with the given name
+// GetChampion returns information about the champion with the given key
 func (c *Client) GetChampionByKey(key string) (ChampionDataExtended, error) {
 	champions, err := c.GetChampions()
 	if err != nil {

--- a/datadragon/data_dragon.go
+++ b/datadragon/data_dragon.go
@@ -143,6 +143,20 @@ func (c *Client) GetChampionByID(id string) (ChampionDataExtended, error) {
 }
 
 // GetChampion returns information about the champion with the given name
+func (c *Client) GetChampionByKey(key string) (ChampionDataExtended, error) {
+	champions, err := c.GetChampions()
+	if err != nil {
+		return ChampionDataExtended{}, err
+	}
+	for _, champion := range champions {
+		if champion.Key == key {
+			return c.GetChampionByID(champion.ID)
+		}
+	}
+	return ChampionDataExtended{}, api.ErrNotFound
+}
+
+// GetChampion returns information about the champion with the given name
 func (c *Client) GetChampion(name string) (ChampionDataExtended, error) {
 	champions, err := c.GetChampions()
 	if err != nil {

--- a/riot/lol/model.go
+++ b/riot/lol/model.go
@@ -608,7 +608,7 @@ type CurrentGameParticipant struct {
 
 // GetChampion returns the champion played by this participant
 func (p *CurrentGameParticipant) GetChampion(client *datadragon.Client) (datadragon.ChampionDataExtended, error) {
-	return client.GetChampionByID(strconv.Itoa(p.ChampionID))
+	return client.GetChampionByKey(strconv.Itoa(p.ChampionID))
 }
 
 // GetSpell1 returns the first summoner spell of this participant


### PR DESCRIPTION
This pull request adds a function to retrieve champion data by passing the champion key as a function parameter.
This change addresses an issue with the current implementation of `CurrentGameParticipant.GetChampion`, which internally calls `client.GetChampionById`. 
Although this might initially seem correct, it is problematic due to the misleading naming of the fields in Data Dragon. The `championId` should be a string representing the code name of the champion, while the returned value in the documentation is the champion key as a number.

![image](https://github.com/KnutZuidema/golio/assets/74204544/5199af43-7180-4065-9efd-f7ff48dff90a)

This update corrects this behavior, ensuring that champions are returned correctly.