### PR TITLE
Fix: Set RegionOceania to correct route

### DIFF
--- a/api/constants.go
+++ b/api/constants.go
@@ -67,7 +67,7 @@ var (
 		RegionLatinAmericaNorth: RouteAmericas,
 		RegionLatinAmericaSouth: RouteAmericas,
 		RegionNorthAmerica:      RouteAmericas,
-		RegionOceania:           RouteAmericas,
+		RegionOceania:           RouteSEA,
 		RegionPhilippines:       RouteSEA,
 		RegionRussia:            RouteEurope,
 		RegionSingapore:         RouteSEA,


### PR DESCRIPTION
This commit corrects the mapping of RegionOceania to the correct RouteSEA in the `api/constants.go` file. Previously, the mapping was incorrect, leading to potential routing issues. This fix ensures that requests for the Oceania region are correctly routed