### PR TITLE
Add league-v4/by-puuid endpoint

### DIFF
--- a/riot/lol/constants.go
+++ b/riot/lol/constants.go
@@ -23,6 +23,7 @@ const (
 	endpointGetGrandmasterLeague               = endpointLeagueBase + "/grandmasterleagues/by-queue/%s"
 	endpointGetMasterLeague                    = endpointLeagueBase + "/masterleagues/by-queue/%s"
 	endpointGetLeaguesBySummoner               = endpointLeagueBase + "/entries/by-summoner/%s"
+	endpointGetLeaguesByPuuid                  = endpointLeagueBase + "/entries/by-puuid/%s"
 	endpointGetLeagues                         = endpointLeagueBase + "/entries/%s/%s/%s"
 	endpointGetLeague                          = endpointLeagueBase + "/leagues/%s"
 	endpointStatusBase                         = endpointBase + "/status/v3"

--- a/riot/lol/league.go
+++ b/riot/lol/league.go
@@ -57,6 +57,17 @@ func (l *LeagueClient) ListBySummoner(summonerID string) ([]*LeagueItem, error) 
 	return leagues, nil
 }
 
+// ListByPuuid returns all leagues a summoner with the given puuid is in
+func (l *LeagueClient) ListByPuuid(puuid string) ([]*LeagueItem, error) {
+	logger := l.logger().WithField("method", "ListByPuuid")
+	var leagues []*LeagueItem
+	if err := l.c.GetInto(fmt.Sprintf(endpointGetLeaguesByPuuid, puuid), &leagues); err != nil {
+		logger.Debug(err)
+		return nil, err
+	}
+	return leagues, nil
+}
+
 // ListPlayers returns all players with a league specified by its queue, tier and division
 func (l *LeagueClient) ListPlayers(queue queue, tier tier, division division) ([]*LeagueItem, error) {
 	logger := l.logger().WithField("method", "ListPlayers")

--- a/riot/lol/league_test.go
+++ b/riot/lol/league_test.go
@@ -179,8 +179,6 @@ func TestLeagueClient_ListBySummoner(t *testing.T) {
 	}
 }
 
-
-
 func TestLeagueClient_ListByPuuid(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/riot/lol/league_test.go
+++ b/riot/lol/league_test.go
@@ -179,6 +179,42 @@ func TestLeagueClient_ListBySummoner(t *testing.T) {
 	}
 }
 
+
+
+func TestLeagueClient_ListByPuuid(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		want    []*LeagueItem
+		doer    internal.Doer
+		wantErr error
+	}{
+		{
+			name: "get response",
+			want: []*LeagueItem{},
+			doer: mock.NewJSONMockDoer([]*LeagueItem{}, 200),
+		},
+		{
+			name:    "not found",
+			wantErr: api.ErrNotFound,
+			doer:    mock.NewStatusMockDoer(http.StatusNotFound),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				client := internal.NewClient(api.RegionEuropeWest, "API_KEY", tt.doer, logrus.StandardLogger())
+				got, err := (&LeagueClient{c: client}).ListByPuuid("id")
+				require.Equal(t, err, tt.wantErr, fmt.Sprintf("want err %v, got %v", tt.wantErr, err))
+				if tt.wantErr == nil {
+					assert.Equal(t, got, tt.want)
+				}
+			},
+		)
+	}
+}
+
+
 func TestLeagueClient_Get(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/riot/lol/model.go
+++ b/riot/lol/model.go
@@ -104,6 +104,7 @@ type LeagueItem struct {
 	Tier         string      `json:"tier"`
 	Rank         string      `json:"rank"`
 	SummonerID   string      `json:"summonerId"`
+	PUUID        string      `json:"puuid"`
 	LeaguePoints int         `json:"leaguePoints"`
 }
 


### PR DESCRIPTION
As seen here, https://github.com/RiotGames/developer-relations/issues/708 Riot added the puuid to the league-v4 responses and also added a league-v4 method called /by-puuid. I added these to golio, most likely also with all the required tests