### PR TITLE
add GetEntriesByPUUID method in TFT

### DIFF
--- a/riot/lol/model.go
+++ b/riot/lol/model.go
@@ -141,6 +141,8 @@ type MatchMetadata struct {
 
 // MatchInfo contains the data for a specific match
 type MatchInfo struct {
+	// Refer to indicate if the game ended in termination.
+	EndOfGameResult string `json:"endOfGameResult"`
 	// Unix timestamp for when the game is created on the game server (i.e., the loading screen).
 	GameCreation int64 `json:"gameCreation"`
 	// Prior to patch 11.20, this field returns the game length in milliseconds calculated
@@ -227,10 +229,180 @@ type ParticipantPerks struct {
 	Styles    []Styles   `json:"styles"`
 }
 
+// ChallengesDto holds the challenge statistics for a participant in a match.
+// Not every field is populated for every game mode; unpopulated fields are left at their zero value.
+type ChallengesDto struct {
+	TwelveAssistStreakCount                   int     `json:"12AssistStreakCount"`
+	BaronBuffGoldAdvantageOverThreshold       int     `json:"baronBuffGoldAdvantageOverThreshold"`
+	ControlWardTimeCoverageInRiverOrEnemyHalf float64 `json:"controlWardTimeCoverageInRiverOrEnemyHalf"`
+	EarliestBaron                             int     `json:"earliestBaron"`
+	EarliestDragonTakedown                    int     `json:"earliestDragonTakedown"`
+	EarliestElderDragon                       int     `json:"earliestElderDragon"`
+	EarlyLaningPhaseGoldExpAdvantage          int     `json:"earlyLaningPhaseGoldExpAdvantage"`
+	FasterSupportQuestCompletion              int     `json:"fasterSupportQuestCompletion"`
+	FastestLegendary                          int     `json:"fastestLegendary"`
+	HadAfkTeammate                            int     `json:"hadAfkTeammate"`
+	HighestChampionDamage                     int     `json:"highestChampionDamage"`
+	HighestCrowdControlScore                  int     `json:"highestCrowdControlScore"`
+	HighestWardKills                          int     `json:"highestWardKills"`
+	JunglerKillsEarlyJungle                   int     `json:"junglerKillsEarlyJungle"`
+	KillsOnLanersEarlyJungleAsJungler         int     `json:"killsOnLanersEarlyJungleAsJungler"`
+	LaningPhaseGoldExpAdvantage               int     `json:"laningPhaseGoldExpAdvantage"`
+	LegendaryCount                            int     `json:"legendaryCount"`
+	MaxCsAdvantageOnLaneOpponent              float64 `json:"maxCsAdvantageOnLaneOpponent"`
+	MaxLevelLeadLaneOpponent                  int     `json:"maxLevelLeadLaneOpponent"`
+	MostWardsDestroyedOneSweeper              int     `json:"mostWardsDestroyedOneSweeper"`
+	MythicItemUsed                            int     `json:"mythicItemUsed"`
+	PlayedChampSelectPosition                 int     `json:"playedChampSelectPosition"`
+	SoloTurretsLategame                       int     `json:"soloTurretsLategame"`
+	TakedownsFirst25Minutes                   int     `json:"takedownsFirst25Minutes"`
+	TeleportTakedowns                         int     `json:"teleportTakedowns"`
+	ThirdInhibitorDestroyedTime               int     `json:"thirdInhibitorDestroyedTime"`
+	ThreeWardsOneSweeperCount                 int     `json:"threeWardsOneSweeperCount"`
+	VisionScoreAdvantageLaneOpponent          float64 `json:"visionScoreAdvantageLaneOpponent"`
+	InfernalScalePickup                       int     `json:"InfernalScalePickup"`
+	FistBumpParticipation                     int     `json:"fistBumpParticipation"`
+	VoidMonsterKill                           int     `json:"voidMonsterKill"`
+	AbilityUses                               int     `json:"abilityUses"`
+	AcesBefore15Minutes                       int     `json:"acesBefore15Minutes"`
+	AlliedJungleMonsterKills                  float64 `json:"alliedJungleMonsterKills"`
+	BaronTakedowns                            int     `json:"baronTakedowns"`
+	BlastConeOppositeOpponentCount            int     `json:"blastConeOppositeOpponentCount"`
+	BountyGold                                int     `json:"bountyGold"`
+	BuffsStolen                               int     `json:"buffsStolen"`
+	CompleteSupportQuestInTime                int     `json:"completeSupportQuestInTime"`
+	ControlWardsPlaced                        int     `json:"controlWardsPlaced"`
+	DamagePerMinute                           float64 `json:"damagePerMinute"`
+	DamageTakenOnTeamPercentage               float64 `json:"damageTakenOnTeamPercentage"`
+	DancedWithRiftHerald                      int     `json:"dancedWithRiftHerald"`
+	DeathsByEnemyChamps                       int     `json:"deathsByEnemyChamps"`
+	DodgeSkillShotsSmallWindow                int     `json:"dodgeSkillShotsSmallWindow"`
+	DoubleAces                                int     `json:"doubleAces"`
+	DragonTakedowns                           int     `json:"dragonTakedowns"`
+	LegendaryItemUsed                         []int   `json:"legendaryItemUsed"`
+	EffectiveHealAndShielding                 float64 `json:"effectiveHealAndShielding"`
+	ElderDragonKillsWithOpposingSoul          int     `json:"elderDragonKillsWithOpposingSoul"`
+	ElderDragonMultikills                     int     `json:"elderDragonMultikills"`
+	EnemyChampionImmobilizations              int     `json:"enemyChampionImmobilizations"`
+	EnemyJungleMonsterKills                   float64 `json:"enemyJungleMonsterKills"`
+	EpicMonsterKillsNearEnemyJungler          int     `json:"epicMonsterKillsNearEnemyJungler"`
+	EpicMonsterKillsWithin30SecondsOfSpawn    int     `json:"epicMonsterKillsWithin30SecondsOfSpawn"`
+	EpicMonsterSteals                         int     `json:"epicMonsterSteals"`
+	EpicMonsterStolenWithoutSmite             int     `json:"epicMonsterStolenWithoutSmite"`
+	FirstTurretKilled                         int     `json:"firstTurretKilled"`
+	FirstTurretKilledTime                     float64 `json:"firstTurretKilledTime"`
+	FlawlessAces                              int     `json:"flawlessAces"`
+	FullTeamTakedown                          int     `json:"fullTeamTakedown"`
+	GameLength                                float64 `json:"gameLength"`
+	GetTakedownsInAllLanesEarlyJungleAsLaner  int     `json:"getTakedownsInAllLanesEarlyJungleAsLaner"`
+	GoldPerMinute                             float64 `json:"goldPerMinute"`
+	HadOpenNexus                              int     `json:"hadOpenNexus"`
+	ImmobilizeAndKillWithAlly                 int     `json:"immobilizeAndKillWithAlly"`
+	InitialBuffCount                          int     `json:"initialBuffCount"`
+	InitialCrabCount                          int     `json:"initialCrabCount"`
+	JungleCsBefore10Minutes                   float64 `json:"jungleCsBefore10Minutes"`
+	JunglerTakedownsNearDamagedEpicMonster    int     `json:"junglerTakedownsNearDamagedEpicMonster"`
+	KDA                                       float64 `json:"kda"`
+	KillAfterHiddenWithAlly                   int     `json:"killAfterHiddenWithAlly"`
+	KilledChampTookFullTeamDamageSurvived     int     `json:"killedChampTookFullTeamDamageSurvived"`
+	KillingSprees                             int     `json:"killingSprees"`
+	KillParticipation                         float64 `json:"killParticipation"`
+	KillsNearEnemyTurret                      int     `json:"killsNearEnemyTurret"`
+	KillsOnOtherLanesEarlyJungleAsLaner       int     `json:"killsOnOtherLanesEarlyJungleAsLaner"`
+	KillsOnRecentlyHealedByAramPack           int     `json:"killsOnRecentlyHealedByAramPack"`
+	KillsUnderOwnTurret                       int     `json:"killsUnderOwnTurret"`
+	KillsWithHelpFromEpicMonster              int     `json:"killsWithHelpFromEpicMonster"`
+	KnockEnemyIntoTeamAndKill                 int     `json:"knockEnemyIntoTeamAndKill"`
+	KTurretsDestroyedBeforePlatesFall         int     `json:"kTurretsDestroyedBeforePlatesFall"`
+	LandSkillShotsEarlyGame                   int     `json:"landSkillShotsEarlyGame"`
+	LaneMinionsFirst10Minutes                 int     `json:"laneMinionsFirst10Minutes"`
+	LostAnInhibitor                           int     `json:"lostAnInhibitor"`
+	MaxKillDeficit                            int     `json:"maxKillDeficit"`
+	MejaisFullStackInTime                     int     `json:"mejaisFullStackInTime"`
+	MoreEnemyJungleThanOpponent               float64 `json:"moreEnemyJungleThanOpponent"`
+	MultiKillOneSpell                         int     `json:"multiKillOneSpell"`
+	Multikills                                int     `json:"multikills"`
+	MultikillsAfterAggressiveFlash            int     `json:"multikillsAfterAggressiveFlash"`
+	MultiTurretRiftHeraldCount                int     `json:"multiTurretRiftHeraldCount"`
+	OuterTurretExecutesBefore10Minutes        int     `json:"outerTurretExecutesBefore10Minutes"`
+	OutnumberedKills                          int     `json:"outnumberedKills"`
+	OutnumberedNexusKill                      int     `json:"outnumberedNexusKill"`
+	PerfectDragonSoulsTaken                   int     `json:"perfectDragonSoulsTaken"`
+	PerfectGame                               int     `json:"perfectGame"`
+	PickKillWithAlly                          int     `json:"pickKillWithAlly"`
+	PoroExplosions                            int     `json:"poroExplosions"`
+	QuickCleanse                              int     `json:"quickCleanse"`
+	QuickFirstTurret                          int     `json:"quickFirstTurret"`
+	QuickSoloKills                            int     `json:"quickSoloKills"`
+	RiftHeraldTakedowns                       int     `json:"riftHeraldTakedowns"`
+	SaveAllyFromDeath                         int     `json:"saveAllyFromDeath"`
+	ScuttleCrabKills                          int     `json:"scuttleCrabKills"`
+	ShortestTimeToAceFromFirstTakedown        float64 `json:"shortestTimeToAceFromFirstTakedown"`
+	SkillshotsDodged                          int     `json:"skillshotsDodged"`
+	SkillshotsHit                             int     `json:"skillshotsHit"`
+	SnowballsHit                              int     `json:"snowballsHit"`
+	SoloBaronKills                            int     `json:"soloBaronKills"`
+	SWARMDefeatAatrox                         int     `json:"SWARM_DefeatAatrox"`
+	SWARMDefeatBriar                          int     `json:"SWARM_DefeatBriar"`
+	SWARMDefeatMiniBosses                     int     `json:"SWARM_DefeatMiniBosses"`
+	SWARMEvolveWeapon                         int     `json:"SWARM_EvolveWeapon"`
+	SWARMHave3Passives                        int     `json:"SWARM_Have3Passives"`
+	SWARMKillEnemy                            int     `json:"SWARM_KillEnemy"`
+	SWARMPickupGold                           float64 `json:"SWARM_PickupGold"`
+	SWARMReachLevel50                         int     `json:"SWARM_ReachLevel50"`
+	SWARMSurvive15Min                         int     `json:"SWARM_Survive15Min"`
+	SWARMWinWith5EvolvedWeapons               int     `json:"SWARM_WinWith5EvolvedWeapons"`
+	SoloKills                                 int     `json:"soloKills"`
+	StealthWardsPlaced                        int     `json:"stealthWardsPlaced"`
+	SurvivedSingleDigitHpCount                int     `json:"survivedSingleDigitHpCount"`
+	SurvivedThreeImmobilizesInFight           int     `json:"survivedThreeImmobilizesInFight"`
+	TakedownOnFirstTurret                     int     `json:"takedownOnFirstTurret"`
+	Takedowns                                 int     `json:"takedowns"`
+	TakedownsAfterGainingLevelAdvantage       int     `json:"takedownsAfterGainingLevelAdvantage"`
+	TakedownsBeforeJungleMinionSpawn          int     `json:"takedownsBeforeJungleMinionSpawn"`
+	TakedownsFirstXMinutes                    int     `json:"takedownsFirstXMinutes"`
+	TakedownsInAlcove                         int     `json:"takedownsInAlcove"`
+	TakedownsInEnemyFountain                  int     `json:"takedownsInEnemyFountain"`
+	TeamBaronKills                            int     `json:"teamBaronKills"`
+	TeamDamagePercentage                      float64 `json:"teamDamagePercentage"`
+	TeamElderDragonKills                      int     `json:"teamElderDragonKills"`
+	TeamRiftHeraldKills                       int     `json:"teamRiftHeraldKills"`
+	TookLargeDamageSurvived                   int     `json:"tookLargeDamageSurvived"`
+	TurretPlatesTaken                         int     `json:"turretPlatesTaken"`
+	TurretsTakenWithRiftHerald                int     `json:"turretsTakenWithRiftHerald"`
+	TurretTakedowns                           int     `json:"turretTakedowns"`
+	TwentyMinionsIn3SecondsCount              int     `json:"twentyMinionsIn3SecondsCount"`
+	TwoWardsOneSweeperCount                   int     `json:"twoWardsOneSweeperCount"`
+	UnseenRecalls                             int     `json:"unseenRecalls"`
+	VisionScorePerMinute                      float64 `json:"visionScorePerMinute"`
+	WardsGuarded                              int     `json:"wardsGuarded"`
+	WardTakedowns                             int     `json:"wardTakedowns"`
+	WardTakedownsBefore20M                    int     `json:"wardTakedownsBefore20M"`
+}
+
+// MissionsDto holds the mission player scores for a participant in a match
+type MissionsDto struct {
+	PlayerScore0  int `json:"playerScore0"`
+	PlayerScore1  int `json:"playerScore1"`
+	PlayerScore2  int `json:"playerScore2"`
+	PlayerScore3  int `json:"playerScore3"`
+	PlayerScore4  int `json:"playerScore4"`
+	PlayerScore5  int `json:"playerScore5"`
+	PlayerScore6  int `json:"playerScore6"`
+	PlayerScore7  int `json:"playerScore7"`
+	PlayerScore8  int `json:"playerScore8"`
+	PlayerScore9  int `json:"playerScore9"`
+	PlayerScore10 int `json:"playerScore10"`
+	PlayerScore11 int `json:"playerScore11"`
+}
+
 // Participant hold information for a participant of a match
 type Participant struct {
+	AllInPings      int `json:"allInPings"`    // Yellow crossed swords
+	AssistMePings   int `json:"assistMePings"` // Green flag
 	Assists         int `json:"assists"`
 	BaronKills      int `json:"baronKills"`
+	BasicPings      int `json:"basicPings"`
 	BountyLevel     int `json:"bountyLevel"`
 	ChampExperience int `json:"champExperience"`
 	ChampLevel      int `json:"champLevel"`
@@ -240,24 +412,32 @@ type Participant struct {
 	ChampionName string `json:"championName"`
 	// This field is currently only utilized for Kayn's transformations.
 	// (Legal values: 0 - None, 1 - Slayer, 2 - Assassin)
-	ChampionTransform         int  `json:"championTransform"`
-	ConsumablesPurchased      int  `json:"consumablesPurchased"`
-	DamageDealtToBuildings    int  `json:"damageDealtToBuildings"`
-	DamageDealtToObjectives   int  `json:"damageDealtToObjectives"`
-	DamageDealtToTurrets      int  `json:"damageDealtToTurrets"`
-	DamageSelfMitigated       int  `json:"damageSelfMitigated"`
-	Deaths                    int  `json:"deaths"`
-	DetectorWardsPlaced       int  `json:"detectorWardsPlaced"`
-	DoubleKills               int  `json:"doubleKills"`
-	DragonKills               int  `json:"dragonKills"`
-	FirstBloodAssist          bool `json:"firstBloodAssist"`
-	FirstBloodKill            bool `json:"firstBloodKill"`
-	FirstTowerAssist          bool `json:"firstTowerAssist"`
-	FirstTowerKill            bool `json:"firstTowerKill"`
-	GameEndedInEarlySurrender bool `json:"gameEndedInEarlySurrender"`
-	GameEndedInSurrender      bool `json:"gameEndedInSurrender"`
-	GoldEarned                int  `json:"goldEarned"`
-	GoldSpent                 int  `json:"goldSpent"`
+	ChampionTransform         int            `json:"championTransform"`
+	Challenges                *ChallengesDto `json:"challenges"`
+	CommandPings              int            `json:"commandPings"` // Blue generic ping (ALT+click)
+	ConsumablesPurchased      int            `json:"consumablesPurchased"`
+	DamageDealtToBuildings    int            `json:"damageDealtToBuildings"`
+	DamageDealtToObjectives   int            `json:"damageDealtToObjectives"`
+	DamageDealtToTurrets      int            `json:"damageDealtToTurrets"`
+	DamageSelfMitigated       int            `json:"damageSelfMitigated"`
+	DangerPings               int            `json:"dangerPings"`
+	Deaths                    int            `json:"deaths"`
+	DetectorWardsPlaced       int            `json:"detectorWardsPlaced"`
+	DoubleKills               int            `json:"doubleKills"`
+	DragonKills               int            `json:"dragonKills"`
+	EligibleForProgression    bool           `json:"eligibleForProgression"`
+	EnemyMissingPings         int            `json:"enemyMissingPings"` // Yellow questionmark
+	EnemyVisionPings          int            `json:"enemyVisionPings"`  // Red eyeball
+	FirstBloodAssist          bool           `json:"firstBloodAssist"`
+	FirstBloodKill            bool           `json:"firstBloodKill"`
+	FirstTowerAssist          bool           `json:"firstTowerAssist"`
+	FirstTowerKill            bool           `json:"firstTowerKill"`
+	GameEndedInEarlySurrender bool           `json:"gameEndedInEarlySurrender"`
+	GameEndedInSurrender      bool           `json:"gameEndedInSurrender"`
+	GetBackPings              int            `json:"getBackPings"` // Yellow circle with horizontal line
+	GoldEarned                int            `json:"goldEarned"`
+	GoldSpent                 int            `json:"goldSpent"`
+	HoldPings                 int            `json:"holdPings"`
 	// Both individualPosition and teamPosition are computed by the game server and are
 	// different versions of the most likely position played by a player. The individualPosition
 	// is the best guess for which position the player actually played in isolation of
@@ -287,19 +467,43 @@ type Participant struct {
 	MagicDamageDealt               int               `json:"magicDamageDealt"`
 	MagicDamageDealtToChampions    int               `json:"magicDamageDealtToChampions"`
 	MagicDamageTaken               int               `json:"magicDamageTaken"`
+	Missions                       *MissionsDto      `json:"missions"`
+	NeedVisionPings                int               `json:"needVisionPings"` // Green ward
 	NeutralMinionsKilled           int               `json:"neutralMinionsKilled"`
 	NexusKills                     int               `json:"nexusKills"`
 	NexusLost                      int               `json:"nexusLost"`
 	NexusTakedowns                 int               `json:"nexusTakedowns"`
 	ObjectivesStolen               int               `json:"objectivesStolen"`
 	ObjectivesStolenAssists        int               `json:"objectivesStolenAssists"`
+	OnMyWayPings                   int               `json:"onMyWayPings"` // Blue arrow pointing at ground
 	ParticipantID                  int               `json:"participantId"`
 	PentaKills                     int               `json:"pentaKills"`
 	Perks                          *ParticipantPerks `json:"perks"`
 	PhysicalDamageDealt            int               `json:"physicalDamageDealt"`
 	PhysicalDamageDealtToChampions int               `json:"physicalDamageDealtToChampions"`
 	PhysicalDamageTaken            int               `json:"physicalDamageTaken"`
+	Placement                      int               `json:"placement"`
+	PlayerAugment1                 int               `json:"playerAugment1"`
+	PlayerAugment2                 int               `json:"playerAugment2"`
+	PlayerAugment3                 int               `json:"playerAugment3"`
+	PlayerAugment4                 int               `json:"playerAugment4"`
+	PlayerAugment5                 int               `json:"playerAugment5"`
+	PlayerAugment6                 int               `json:"playerAugment6"`
+	PlayerScore0                   int               `json:"playerScore0"`
+	PlayerScore1                   int               `json:"playerScore1"`
+	PlayerScore2                   int               `json:"playerScore2"`
+	PlayerScore3                   int               `json:"playerScore3"`
+	PlayerScore4                   int               `json:"playerScore4"`
+	PlayerScore5                   int               `json:"playerScore5"`
+	PlayerScore6                   int               `json:"playerScore6"`
+	PlayerScore7                   int               `json:"playerScore7"`
+	PlayerScore8                   int               `json:"playerScore8"`
+	PlayerScore9                   int               `json:"playerScore9"`
+	PlayerScore10                  int               `json:"playerScore10"`
+	PlayerScore11                  int               `json:"playerScore11"`
+	PlayerSubteamID                int               `json:"playerSubteamId"`
 	ProfileIcon                    int               `json:"profileIcon"`
+	PushPings                      int               `json:"pushPings"` // Green minion
 	PUUID                          string            `json:"puuid"`
 	QuadraKills                    int               `json:"quadraKills"`
 	RiotIDGameName                 string            `json:"riotIdGameName"`
@@ -311,6 +515,7 @@ type Participant struct {
 	Spell2Casts                    int               `json:"spell2Casts"`
 	Spell3Casts                    int               `json:"spell3Casts"`
 	Spell4Casts                    int               `json:"spell4Casts"`
+	SubteamPlacement               int               `json:"subteamPlacement"`
 	Summoner1Casts                 int               `json:"summoner1Casts"`
 	Summoner1ID                    int               `json:"summoner1Id"`
 	Summoner2Casts                 int               `json:"summoner2Casts"`
@@ -330,10 +535,12 @@ type Participant struct {
 	TeamPosition                   string `json:"teamPosition"`
 	TimeCCingOthers                int    `json:"timeCCingOthers"`
 	TimePlayed                     int    `json:"timePlayed"`
+	TotalAllyJungleMinionsKilled   int    `json:"totalAllyJungleMinionsKilled"`
 	TotalDamageDealt               int    `json:"totalDamageDealt"`
 	TotalDamageDealtToChampions    int    `json:"totalDamageDealtToChampions"`
 	TotalDamageShieldedOnTeammates int    `json:"totalDamageShieldedOnTeammates"`
 	TotalDamageTaken               int    `json:"totalDamageTaken"`
+	TotalEnemyJungleMinionsKilled  int    `json:"totalEnemyJungleMinionsKilled"`
 	TotalHeal                      int    `json:"totalHeal"`
 	TotalHealsOnTeammates          int    `json:"totalHealsOnTeammates"`
 	TotalMinionsKilled             int    `json:"totalMinionsKilled"`
@@ -348,6 +555,7 @@ type Participant struct {
 	TurretTakedowns                int    `json:"turretTakedowns"`
 	TurretsLost                    int    `json:"turretsLost"`
 	UnrealKills                    int    `json:"unrealKills"`
+	VisionClearedPings             int    `json:"visionClearedPings"`
 	VisionScore                    int    `json:"visionScore"`
 	VisionWardsBoughtInGame        int    `json:"visionWardsBoughtInGame"`
 	WardsKilled                    int    `json:"wardsKilled"`

--- a/riot/lol/model.go
+++ b/riot/lol/model.go
@@ -235,12 +235,12 @@ type ChallengesDto struct {
 	TwelveAssistStreakCount                   int     `json:"12AssistStreakCount"`
 	BaronBuffGoldAdvantageOverThreshold       int     `json:"baronBuffGoldAdvantageOverThreshold"`
 	ControlWardTimeCoverageInRiverOrEnemyHalf float64 `json:"controlWardTimeCoverageInRiverOrEnemyHalf"`
-	EarliestBaron                             int     `json:"earliestBaron"`
-	EarliestDragonTakedown                    int     `json:"earliestDragonTakedown"`
-	EarliestElderDragon                       int     `json:"earliestElderDragon"`
+	EarliestBaron                             float64 `json:"earliestBaron"`
+	EarliestDragonTakedown                    float64 `json:"earliestDragonTakedown"`
+	EarliestElderDragon                       float64 `json:"earliestElderDragon"`
 	EarlyLaningPhaseGoldExpAdvantage          int     `json:"earlyLaningPhaseGoldExpAdvantage"`
-	FasterSupportQuestCompletion              int     `json:"fasterSupportQuestCompletion"`
-	FastestLegendary                          int     `json:"fastestLegendary"`
+	FasterSupportQuestCompletion              float64 `json:"fasterSupportQuestCompletion"`
+	FastestLegendary                          float64 `json:"fastestLegendary"`
 	HadAfkTeammate                            int     `json:"hadAfkTeammate"`
 	HighestChampionDamage                     int     `json:"highestChampionDamage"`
 	HighestCrowdControlScore                  int     `json:"highestCrowdControlScore"`
@@ -257,7 +257,7 @@ type ChallengesDto struct {
 	SoloTurretsLategame                       int     `json:"soloTurretsLategame"`
 	TakedownsFirst25Minutes                   int     `json:"takedownsFirst25Minutes"`
 	TeleportTakedowns                         int     `json:"teleportTakedowns"`
-	ThirdInhibitorDestroyedTime               int     `json:"thirdInhibitorDestroyedTime"`
+	ThirdInhibitorDestroyedTime               float64 `json:"thirdInhibitorDestroyedTime"`
 	ThreeWardsOneSweeperCount                 int     `json:"threeWardsOneSweeperCount"`
 	VisionScoreAdvantageLaneOpponent          float64 `json:"visionScoreAdvantageLaneOpponent"`
 	InfernalScalePickup                       int     `json:"InfernalScalePickup"`
@@ -268,7 +268,7 @@ type ChallengesDto struct {
 	AlliedJungleMonsterKills                  float64 `json:"alliedJungleMonsterKills"`
 	BaronTakedowns                            int     `json:"baronTakedowns"`
 	BlastConeOppositeOpponentCount            int     `json:"blastConeOppositeOpponentCount"`
-	BountyGold                                int     `json:"bountyGold"`
+	BountyGold                                float64 `json:"bountyGold"`
 	BuffsStolen                               int     `json:"buffsStolen"`
 	CompleteSupportQuestInTime                int     `json:"completeSupportQuestInTime"`
 	ControlWardsPlaced                        int     `json:"controlWardsPlaced"`
@@ -382,18 +382,18 @@ type ChallengesDto struct {
 
 // MissionsDto holds the mission player scores for a participant in a match
 type MissionsDto struct {
-	PlayerScore0  int `json:"playerScore0"`
-	PlayerScore1  int `json:"playerScore1"`
-	PlayerScore2  int `json:"playerScore2"`
-	PlayerScore3  int `json:"playerScore3"`
-	PlayerScore4  int `json:"playerScore4"`
-	PlayerScore5  int `json:"playerScore5"`
-	PlayerScore6  int `json:"playerScore6"`
-	PlayerScore7  int `json:"playerScore7"`
-	PlayerScore8  int `json:"playerScore8"`
-	PlayerScore9  int `json:"playerScore9"`
-	PlayerScore10 int `json:"playerScore10"`
-	PlayerScore11 int `json:"playerScore11"`
+	PlayerScore0  float64 `json:"playerScore0"`
+	PlayerScore1  float64 `json:"playerScore1"`
+	PlayerScore2  float64 `json:"playerScore2"`
+	PlayerScore3  float64 `json:"playerScore3"`
+	PlayerScore4  float64 `json:"playerScore4"`
+	PlayerScore5  float64 `json:"playerScore5"`
+	PlayerScore6  float64 `json:"playerScore6"`
+	PlayerScore7  float64 `json:"playerScore7"`
+	PlayerScore8  float64 `json:"playerScore8"`
+	PlayerScore9  float64 `json:"playerScore9"`
+	PlayerScore10 float64 `json:"playerScore10"`
+	PlayerScore11 float64 `json:"playerScore11"`
 }
 
 // Participant hold information for a participant of a match
@@ -489,18 +489,18 @@ type Participant struct {
 	PlayerAugment4                 int               `json:"playerAugment4"`
 	PlayerAugment5                 int               `json:"playerAugment5"`
 	PlayerAugment6                 int               `json:"playerAugment6"`
-	PlayerScore0                   int               `json:"playerScore0"`
-	PlayerScore1                   int               `json:"playerScore1"`
-	PlayerScore2                   int               `json:"playerScore2"`
-	PlayerScore3                   int               `json:"playerScore3"`
-	PlayerScore4                   int               `json:"playerScore4"`
-	PlayerScore5                   int               `json:"playerScore5"`
-	PlayerScore6                   int               `json:"playerScore6"`
-	PlayerScore7                   int               `json:"playerScore7"`
-	PlayerScore8                   int               `json:"playerScore8"`
-	PlayerScore9                   int               `json:"playerScore9"`
-	PlayerScore10                  int               `json:"playerScore10"`
-	PlayerScore11                  int               `json:"playerScore11"`
+	PlayerScore0                   float64           `json:"playerScore0"`
+	PlayerScore1                   float64           `json:"playerScore1"`
+	PlayerScore2                   float64           `json:"playerScore2"`
+	PlayerScore3                   float64           `json:"playerScore3"`
+	PlayerScore4                   float64           `json:"playerScore4"`
+	PlayerScore5                   float64           `json:"playerScore5"`
+	PlayerScore6                   float64           `json:"playerScore6"`
+	PlayerScore7                   float64           `json:"playerScore7"`
+	PlayerScore8                   float64           `json:"playerScore8"`
+	PlayerScore9                   float64           `json:"playerScore9"`
+	PlayerScore10                  float64           `json:"playerScore10"`
+	PlayerScore11                  float64           `json:"playerScore11"`
 	PlayerSubteamID                int               `json:"playerSubteamId"`
 	ProfileIcon                    int               `json:"profileIcon"`
 	PushPings                      int               `json:"pushPings"` // Green minion

--- a/riot/tft/constants.go
+++ b/riot/tft/constants.go
@@ -10,6 +10,7 @@ const (
 	endpointLeagueBase                = endpointBase + "/league/v1"
 	endpointLeagueChallenger          = endpointLeagueBase + "/challenger?queue=%s"
 	endpointLeagueEntriesBySummoner   = endpointLeagueBase + "/entries/by-summoner/%s"
+	endpointLeagueEntriesByPUUID      = endpointLeagueBase + "/by-puuid/%s"
 	endpointLeagueEntries             = endpointLeagueBase + "/entries/%s/%s"
 	endpointLeagueGrandMaster         = endpointLeagueBase + "/grandmaster?queue=%s"
 	endpointLeagueLeagues             = endpointLeagueBase + "/leagues/%s"

--- a/riot/tft/league.go
+++ b/riot/tft/league.go
@@ -39,6 +39,18 @@ func (lc *LeagueClient) GetEntriesBySummoner(summonerID string) ([]*LeagueEntry,
 	return out, nil
 }
 
+// GetEntriesByPUUID returns league entries for a given summoner ID
+func (lc *LeagueClient) GetEntriesByPUUID(puuid string) ([]*LeagueEntry, error) {
+	logger := lc.logger().WithField("method", "GetEntriesByPUUID")
+	url := fmt.Sprintf(endpointLeagueEntriesByPUUID, puuid)
+	var out []*LeagueEntry
+	if err := lc.c.GetInto(url, &out); err != nil {
+		logger.Debug(err)
+		return nil, err
+	}
+	return out, nil
+}
+
 // GetEntries returns all the league entries
 func (lc *LeagueClient) GetEntries(tier tier, division division) ([]*LeagueEntry, error) {
 	logger := lc.logger().WithField("method", "GetEntries")

--- a/riot/tft/league_test.go
+++ b/riot/tft/league_test.go
@@ -76,6 +76,38 @@ func TestTFTLeague_GetEntriesBySummoner(t *testing.T) {
             },
         )
     }
+
+func TestTFTLeague_GetEntriesByPUUID(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		want    []*LeagueEntry
+		doer    internal.Doer
+		wantErr error
+	}{
+		{
+			name: "get response",
+			want: []*LeagueEntry{},
+			doer: mock.NewJSONMockDoer([]*LeagueEntry{}, 200),
+		},
+		{
+			name:    "not found",
+			wantErr: api.ErrNotFound,
+			doer:    mock.NewStatusMockDoer(http.StatusNotFound),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				client := internal.NewClient(api.RegionEuropeWest, "API_KEY", tt.doer, logrus.StandardLogger())
+				got, err := (&LeagueClient{c: client}).GetEntriesByPUUID("puuid")
+				require.Equal(t, err, tt.wantErr, fmt.Sprintf("want err %v, got %v", tt.wantErr, err))
+				if tt.wantErr == nil {
+					assert.Equal(t, got, tt.want)
+				}
+			},
+		)
+	}
 }
 
 func TestTFTLeague_GetEntries(t *testing.T) {

--- a/riot/tft/league_test.go
+++ b/riot/tft/league_test.go
@@ -1,81 +1,82 @@
 package tft
 
 import (
-    "fmt"
-    "github.com/KnutZuidema/golio/api"
-    "github.com/KnutZuidema/golio/internal"
-    "github.com/KnutZuidema/golio/internal/mock"
-    "github.com/sirupsen/logrus"
-    "github.com/stretchr/testify/assert"
-    "github.com/stretchr/testify/require"
-    "net/http"
-    "testing"
+	"fmt"
+	"github.com/KnutZuidema/golio/api"
+	"github.com/KnutZuidema/golio/internal"
+	"github.com/KnutZuidema/golio/internal/mock"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"testing"
 )
 
 func TestTFTLeague_GetChallenger(t *testing.T) {
-    t.Parallel()
-    tests := []struct {
-        name    string
-        want    *LeagueList
-        doer    internal.Doer
-        wantErr error
-    }{
-        {
-            name: "get response",
-            want: &LeagueList{},
-            doer: mock.NewJSONMockDoer(LeagueList{}, 200),
-        },
-        {
-            name:    "not found",
-            wantErr: api.ErrNotFound,
-            doer:    mock.NewStatusMockDoer(http.StatusNotFound),
-        },
-    }
-    for _, tt := range tests {
-        t.Run(
-            tt.name, func(t *testing.T) {
-                client := internal.NewClient(api.RegionEuropeWest, "API_KEY", tt.doer, logrus.StandardLogger())
-                got, err := (&LeagueClient{c: client}).GetChallenger(QueueRankedTFT)
-                require.Equal(t, err, tt.wantErr, fmt.Sprintf("want err %v, got %v", tt.wantErr, err))
-                if tt.wantErr == nil {
-                    assert.Equal(t, got, tt.want)
-                }
-            },
-        )
-    }
+	t.Parallel()
+	tests := []struct {
+		name    string
+		want    *LeagueList
+		doer    internal.Doer
+		wantErr error
+	}{
+		{
+			name: "get response",
+			want: &LeagueList{},
+			doer: mock.NewJSONMockDoer(LeagueList{}, 200),
+		},
+		{
+			name:    "not found",
+			wantErr: api.ErrNotFound,
+			doer:    mock.NewStatusMockDoer(http.StatusNotFound),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				client := internal.NewClient(api.RegionEuropeWest, "API_KEY", tt.doer, logrus.StandardLogger())
+				got, err := (&LeagueClient{c: client}).GetChallenger(QueueRankedTFT)
+				require.Equal(t, err, tt.wantErr, fmt.Sprintf("want err %v, got %v", tt.wantErr, err))
+				if tt.wantErr == nil {
+					assert.Equal(t, got, tt.want)
+				}
+			},
+		)
+	}
 }
 
 func TestTFTLeague_GetEntriesBySummoner(t *testing.T) {
-    t.Parallel()
-    tests := []struct {
-        name    string
-        want    []*LeagueEntry
-        doer    internal.Doer
-        wantErr error
-    }{
-        {
-            name: "get response",
-            want: []*LeagueEntry{},
-            doer: mock.NewJSONMockDoer([]*LeagueEntry{}, 200),
-        },
-        {
-            name:    "not found",
-            wantErr: api.ErrNotFound,
-            doer:    mock.NewStatusMockDoer(http.StatusNotFound),
-        },
-    }
-    for _, tt := range tests {
-        t.Run(
-            tt.name, func(t *testing.T) {
-                client := internal.NewClient(api.RegionEuropeWest, "API_KEY", tt.doer, logrus.StandardLogger())
-                got, err := (&LeagueClient{c: client}).GetEntriesBySummoner("summonerId")
-                require.Equal(t, err, tt.wantErr, fmt.Sprintf("want err %v, got %v", tt.wantErr, err))
-                if tt.wantErr == nil {
-                    assert.Equal(t, got, tt.want)
-                }
-            },
-        )
-    }
+	t.Parallel()
+	tests := []struct {
+		name    string
+		want    []*LeagueEntry
+		doer    internal.Doer
+		wantErr error
+	}{
+		{
+			name: "get response",
+			want: []*LeagueEntry{},
+			doer: mock.NewJSONMockDoer([]*LeagueEntry{}, 200),
+		},
+		{
+			name:    "not found",
+			wantErr: api.ErrNotFound,
+			doer:    mock.NewStatusMockDoer(http.StatusNotFound),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				client := internal.NewClient(api.RegionEuropeWest, "API_KEY", tt.doer, logrus.StandardLogger())
+				got, err := (&LeagueClient{c: client}).GetEntriesBySummoner("summonerId")
+				require.Equal(t, err, tt.wantErr, fmt.Sprintf("want err %v, got %v", tt.wantErr, err))
+				if tt.wantErr == nil {
+					assert.Equal(t, got, tt.want)
+				}
+			},
+		)
+	}
+}
 
 func TestTFTLeague_GetEntriesByPUUID(t *testing.T) {
 	t.Parallel()
@@ -111,166 +112,166 @@ func TestTFTLeague_GetEntriesByPUUID(t *testing.T) {
 }
 
 func TestTFTLeague_GetEntries(t *testing.T) {
-    t.Parallel()
-    tests := []struct {
-        name    string
-        want    []*LeagueEntry
-        doer    internal.Doer
-        wantErr error
-    }{
-        {
-            name: "get response",
-            want: []*LeagueEntry{},
-            doer: mock.NewJSONMockDoer([]*LeagueEntry{}, 200),
-        },
-        {
-            name:    "not found",
-            wantErr: api.ErrNotFound,
-            doer:    mock.NewStatusMockDoer(http.StatusNotFound),
-        },
-    }
-    for _, tt := range tests {
-        t.Run(
-            tt.name, func(t *testing.T) {
-                client := internal.NewClient(api.RegionEuropeWest, "API_KEY", tt.doer, logrus.StandardLogger())
-                got, err := (&LeagueClient{c: client}).GetEntries("DIAMOND", "I")
-                require.Equal(t, err, tt.wantErr, fmt.Sprintf("want err %v, got %v", tt.wantErr, err))
-                if tt.wantErr == nil {
-                    assert.Equal(t, got, tt.want)
-                }
-            },
-        )
-    }
+	t.Parallel()
+	tests := []struct {
+		name    string
+		want    []*LeagueEntry
+		doer    internal.Doer
+		wantErr error
+	}{
+		{
+			name: "get response",
+			want: []*LeagueEntry{},
+			doer: mock.NewJSONMockDoer([]*LeagueEntry{}, 200),
+		},
+		{
+			name:    "not found",
+			wantErr: api.ErrNotFound,
+			doer:    mock.NewStatusMockDoer(http.StatusNotFound),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				client := internal.NewClient(api.RegionEuropeWest, "API_KEY", tt.doer, logrus.StandardLogger())
+				got, err := (&LeagueClient{c: client}).GetEntries("DIAMOND", "I")
+				require.Equal(t, err, tt.wantErr, fmt.Sprintf("want err %v, got %v", tt.wantErr, err))
+				if tt.wantErr == nil {
+					assert.Equal(t, got, tt.want)
+				}
+			},
+		)
+	}
 }
 
 func TestTFTLeague_GetGrandMaster(t *testing.T) {
-    t.Parallel()
-    tests := []struct {
-        name    string
-        want    *LeagueList
-        doer    internal.Doer
-        wantErr error
-    }{
-        {
-            name: "get response",
-            want: &LeagueList{},
-            doer: mock.NewJSONMockDoer(&LeagueList{}, 200),
-        },
-        {
-            name:    "not found",
-            wantErr: api.ErrNotFound,
-            doer:    mock.NewStatusMockDoer(http.StatusNotFound),
-        },
-    }
-    for _, tt := range tests {
-        t.Run(
-            tt.name, func(t *testing.T) {
-                client := internal.NewClient(api.RegionEuropeWest, "API_KEY", tt.doer, logrus.StandardLogger())
-                got, err := (&LeagueClient{c: client}).GetGrandMaster(QueueRankedTFT)
-                require.Equal(t, err, tt.wantErr, fmt.Sprintf("want err %v, got %v", tt.wantErr, err))
-                if tt.wantErr == nil {
-                    assert.Equal(t, got, tt.want)
-                }
-            },
-        )
-    }
+	t.Parallel()
+	tests := []struct {
+		name    string
+		want    *LeagueList
+		doer    internal.Doer
+		wantErr error
+	}{
+		{
+			name: "get response",
+			want: &LeagueList{},
+			doer: mock.NewJSONMockDoer(&LeagueList{}, 200),
+		},
+		{
+			name:    "not found",
+			wantErr: api.ErrNotFound,
+			doer:    mock.NewStatusMockDoer(http.StatusNotFound),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				client := internal.NewClient(api.RegionEuropeWest, "API_KEY", tt.doer, logrus.StandardLogger())
+				got, err := (&LeagueClient{c: client}).GetGrandMaster(QueueRankedTFT)
+				require.Equal(t, err, tt.wantErr, fmt.Sprintf("want err %v, got %v", tt.wantErr, err))
+				if tt.wantErr == nil {
+					assert.Equal(t, got, tt.want)
+				}
+			},
+		)
+	}
 }
 
 func TestTFTLeague_GetLeagues(t *testing.T) {
-    t.Parallel()
-    tests := []struct {
-        name    string
-        want    *LeagueList
-        doer    internal.Doer
-        wantErr error
-    }{
-        {
-            name: "get response",
-            want: &LeagueList{},
-            doer: mock.NewJSONMockDoer(&LeagueList{}, 200),
-        },
-        {
-            name:    "not found",
-            wantErr: api.ErrNotFound,
-            doer:    mock.NewStatusMockDoer(http.StatusNotFound),
-        },
-    }
-    for _, tt := range tests {
-        t.Run(
-            tt.name, func(t *testing.T) {
-                client := internal.NewClient(api.RegionEuropeWest, "API_KEY", tt.doer, logrus.StandardLogger())
-                got, err := (&LeagueClient{c: client}).GetLeagues("1234")
-                require.Equal(t, err, tt.wantErr, fmt.Sprintf("want err %v, got %v", tt.wantErr, err))
-                if tt.wantErr == nil {
-                    assert.Equal(t, got, tt.want)
-                }
-            },
-        )
-    }
+	t.Parallel()
+	tests := []struct {
+		name    string
+		want    *LeagueList
+		doer    internal.Doer
+		wantErr error
+	}{
+		{
+			name: "get response",
+			want: &LeagueList{},
+			doer: mock.NewJSONMockDoer(&LeagueList{}, 200),
+		},
+		{
+			name:    "not found",
+			wantErr: api.ErrNotFound,
+			doer:    mock.NewStatusMockDoer(http.StatusNotFound),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				client := internal.NewClient(api.RegionEuropeWest, "API_KEY", tt.doer, logrus.StandardLogger())
+				got, err := (&LeagueClient{c: client}).GetLeagues("1234")
+				require.Equal(t, err, tt.wantErr, fmt.Sprintf("want err %v, got %v", tt.wantErr, err))
+				if tt.wantErr == nil {
+					assert.Equal(t, got, tt.want)
+				}
+			},
+		)
+	}
 }
 
 func TestTFTLeague_GetMaster(t *testing.T) {
-    t.Parallel()
-    tests := []struct {
-        name    string
-        want    *LeagueList
-        doer    internal.Doer
-        wantErr error
-    }{
-        {
-            name: "get response",
-            want: &LeagueList{},
-            doer: mock.NewJSONMockDoer(&LeagueList{}, 200),
-        },
-        {
-            name:    "not found",
-            wantErr: api.ErrNotFound,
-            doer:    mock.NewStatusMockDoer(http.StatusNotFound),
-        },
-    }
-    for _, tt := range tests {
-        t.Run(
-            tt.name, func(t *testing.T) {
-                client := internal.NewClient(api.RegionEuropeWest, "API_KEY", tt.doer, logrus.StandardLogger())
-                got, err := (&LeagueClient{c: client}).GetMaster(QueueRankedTFT)
-                require.Equal(t, err, tt.wantErr, fmt.Sprintf("want err %v, got %v", tt.wantErr, err))
-                if tt.wantErr == nil {
-                    assert.Equal(t, got, tt.want)
-                }
-            },
-        )
-    }
+	t.Parallel()
+	tests := []struct {
+		name    string
+		want    *LeagueList
+		doer    internal.Doer
+		wantErr error
+	}{
+		{
+			name: "get response",
+			want: &LeagueList{},
+			doer: mock.NewJSONMockDoer(&LeagueList{}, 200),
+		},
+		{
+			name:    "not found",
+			wantErr: api.ErrNotFound,
+			doer:    mock.NewStatusMockDoer(http.StatusNotFound),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				client := internal.NewClient(api.RegionEuropeWest, "API_KEY", tt.doer, logrus.StandardLogger())
+				got, err := (&LeagueClient{c: client}).GetMaster(QueueRankedTFT)
+				require.Equal(t, err, tt.wantErr, fmt.Sprintf("want err %v, got %v", tt.wantErr, err))
+				if tt.wantErr == nil {
+					assert.Equal(t, got, tt.want)
+				}
+			},
+		)
+	}
 }
 
 func TestTFTLeague_GetRatedLaddersByQueue(t *testing.T) {
-    t.Parallel()
-    tests := []struct {
-        name    string
-        want    []*TopRatedLadderEntry
-        doer    internal.Doer
-        wantErr error
-    }{
-        {
-            name: "get response",
-            want: []*TopRatedLadderEntry{},
-            doer: mock.NewJSONMockDoer([]*TopRatedLadderEntry{}, 200),
-        },
-        {
-            name:    "not found",
-            wantErr: api.ErrNotFound,
-            doer:    mock.NewStatusMockDoer(http.StatusNotFound),
-        },
-    }
-    for _, tt := range tests {
-        t.Run(
-            tt.name, func(t *testing.T) {
-                client := internal.NewClient(api.RegionEuropeWest, "API_KEY", tt.doer, logrus.StandardLogger())
-                got, err := (&LeagueClient{c: client}).GetRatedLaddersByQueue(QueueRankedTFT)
-                require.Equal(t, err, tt.wantErr, fmt.Sprintf("want err %v, got %v", tt.wantErr, err))
-                if tt.wantErr == nil {
-                    assert.Equal(t, got, tt.want)
-                }
-            },
-        )
-    }
+	t.Parallel()
+	tests := []struct {
+		name    string
+		want    []*TopRatedLadderEntry
+		doer    internal.Doer
+		wantErr error
+	}{
+		{
+			name: "get response",
+			want: []*TopRatedLadderEntry{},
+			doer: mock.NewJSONMockDoer([]*TopRatedLadderEntry{}, 200),
+		},
+		{
+			name:    "not found",
+			wantErr: api.ErrNotFound,
+			doer:    mock.NewStatusMockDoer(http.StatusNotFound),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				client := internal.NewClient(api.RegionEuropeWest, "API_KEY", tt.doer, logrus.StandardLogger())
+				got, err := (&LeagueClient{c: client}).GetRatedLaddersByQueue(QueueRankedTFT)
+				require.Equal(t, err, tt.wantErr, fmt.Sprintf("want err %v, got %v", tt.wantErr, err))
+				if tt.wantErr == nil {
+					assert.Equal(t, got, tt.want)
+				}
+			},
+		)
+	}
 }


### PR DESCRIPTION
Add [`/tft/league/v1/by-puuid/{puuid}`](https://developer.riotgames.com/apis#tft-league-v1/GET_getLeagueEntriesByPUUID), which is listed in Riot API documents but has not been implemented.

Also, `GetEntriesBySummoner` might not be valid (not listed in docs), but I haven't checked yet.